### PR TITLE
AutoEP: remove grouped_mm_backend surface

### DIFF
--- a/deepspeed/module_inject/auto_ep_config.py
+++ b/deepspeed/module_inject/auto_ep_config.py
@@ -85,7 +85,6 @@ class AutoEPConfig:
     expert_pattern: str | None = None
     router_pattern: str | None = None
     use_grouped_mm: bool = True
-    grouped_mm_backend: Literal["auto", "torch", "cutlass", "sequential"] = "auto"
     route_norm: bool | None = None  # None = auto-detect from model config
     route_scale: float = 1.0
     score_apply: Literal["auto", "pre", "post"] = "auto"
@@ -295,7 +294,6 @@ def parse_autoep_config(param_dict: dict) -> AutoEPConfig:
     config.expert_pattern = param_dict.get("expert_pattern", None)
     config.router_pattern = param_dict.get("router_pattern", None)
     config.use_grouped_mm = param_dict.get("use_grouped_mm", True)
-    config.grouped_mm_backend = param_dict.get("grouped_mm_backend", "auto")
     config.route_norm = param_dict.get("route_norm", None)
     config.route_scale = param_dict.get("route_scale", 1.0)
     config.score_apply = param_dict.get("score_apply", "auto")
@@ -359,12 +357,6 @@ def validate_autoep_config(
     if config.preset_model is not None and config.preset_model not in PRESET_MODELS:
         raise ValueError(f"Unknown preset_model '{config.preset_model}'. "
                          f"Available presets: {list(PRESET_MODELS.keys())}")
-
-    # Validate grouped_mm_backend
-    valid_backends = ("auto", "torch", "cutlass", "sequential")
-    if config.grouped_mm_backend not in valid_backends:
-        raise ValueError(f"grouped_mm_backend must be one of {valid_backends}, "
-                         f"got '{config.grouped_mm_backend}'")
 
     # Validate score_apply
     valid_score_apply = ("auto", "pre", "post")

--- a/deepspeed/moe/ep_experts.py
+++ b/deepspeed/moe/ep_experts.py
@@ -12,24 +12,19 @@ Grouped expert computation for expert parallelism.
 
 Ported from TorchTitan's GroupedExperts with adaptations for DeepSpeed:
   - Replaced hardcoded .bfloat16() with input-dtype-aware casting
-  - Runtime check for torch._grouped_mm availability with fallback
+  - Fail-fast RuntimeError when use_grouped_mm=True but torch._grouped_mm is unavailable
   - Removed DTensor-specific code paths
-  - CUTLASS backend raises NotImplementedError
 
 This module is self-contained: no imports from deepspeed.module_inject
 or deepspeed.runtime.
 """
 
-import logging
-
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-logger = logging.getLogger(__name__)
-
 # ---------------------------------------------------------------------------
-# Expert computation: for-loop fallback
+# Expert computation: sequential for-loop (reference path)
 # ---------------------------------------------------------------------------
 
 
@@ -141,13 +136,14 @@ def _run_experts_grouped_mm(
 class GroupedExperts(nn.Module):
     """Grouped expert computation for MoE layers.
 
-    Supports two backends:
+    Supports two execution paths:
       - **grouped_mm**: Uses ``torch._grouped_mm`` for fused grouped GEMM
         (requires a sufficiently recent PyTorch build).
       - **for-loop**: Sequential per-expert matmuls; always available.
 
-    If ``use_grouped_mm=True`` but ``torch._grouped_mm`` is not available,
-    falls back to the for-loop implementation with a warning.
+    If ``use_grouped_mm=True`` but ``torch._grouped_mm`` is not available, the
+    constructor raises ``RuntimeError``. Set ``use_grouped_mm=False`` to select
+    the sequential for-loop path without checking ``torch._grouped_mm``.
 
     Args:
         dim (int): Input / output dimension.
@@ -169,12 +165,12 @@ class GroupedExperts(nn.Module):
         self.w2 = nn.Parameter(torch.empty(num_experts, dim, hidden_dim))
         self.w3 = nn.Parameter(torch.empty(num_experts, hidden_dim, dim))
 
-        # Check grouped_mm availability at construction time
-        self._has_grouped_mm = hasattr(torch, "_grouped_mm")
-        if use_grouped_mm and not self._has_grouped_mm:
-            logger.warning("torch._grouped_mm not available, falling back to "
-                           "for-loop expert computation")
-        self.use_grouped_mm = use_grouped_mm and self._has_grouped_mm
+        if use_grouped_mm and not hasattr(torch, "_grouped_mm"):
+            raise RuntimeError("GroupedExperts was constructed with use_grouped_mm=True but "
+                               "torch._grouped_mm is not available in this PyTorch build. "
+                               "Upgrade PyTorch to a build that provides torch._grouped_mm, or "
+                               "set use_grouped_mm=False to use the sequential expert loop.")
+        self.use_grouped_mm = use_grouped_mm
 
     def forward(
         self,

--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -897,7 +897,7 @@ Configure AutoEP expert parallelism for MoE models. AutoEP automatically detects
 
 | Description                                                                                    | Default |
 | ---------------------------------------------------------------------------------------------- | ------- |
-| Use `torch._grouped_mm` for fused grouped GEMM. Falls back to sequential for-loop if unavailable. | `true`  |
+| Use `torch._grouped_mm` for fused grouped GEMM. Raises `RuntimeError` at `GroupedExperts` construction time when `torch._grouped_mm` is unavailable; set `use_grouped_mm=false` to use the sequential for-loop. | `true`  |
 
 ***moe_layer_pattern***: [string]
 
@@ -916,12 +916,6 @@ Configure AutoEP expert parallelism for MoE models. AutoEP automatically detects
 | Description                                                                                 | Default |
 | ------------------------------------------------------------------------------------------- | ------- |
 | Direct child attribute name for the experts module (e.g., `"experts"`). Not a regex.        | `null`  |
-
-***grouped_mm_backend***: [string]
-
-| Description                                                                                                                | Default  |
-| -------------------------------------------------------------------------------------------------------------------------- | -------- |
-| Backend for grouped GEMM: `"auto"` (select best available), `"torch"`, `"cutlass"`, or `"sequential"` (for-loop fallback). | `"auto"` |
 
 ***score_func***: [string]
 

--- a/tests/unit/moe/test_autoep_unit.py
+++ b/tests/unit/moe/test_autoep_unit.py
@@ -38,7 +38,6 @@ class TestAutoEPConfig:
         assert config.expert_pattern is None
         assert config.router_pattern is None
         assert config.use_grouped_mm is True
-        assert config.grouped_mm_backend == "auto"
         assert config.route_norm is None
         assert config.route_scale == 1.0
         assert config.score_apply == "auto"
@@ -89,7 +88,6 @@ class TestAutoEPConfig:
             "expert_pattern": "experts",
             "router_pattern": "gate",
             "use_grouped_mm": False,
-            "grouped_mm_backend": "sequential",
             "route_norm": True,
             "route_scale": 2.0,
             "score_apply": "pre",
@@ -116,7 +114,6 @@ class TestAutoEPConfig:
         assert config.expert_pattern == "experts"
         assert config.router_pattern == "gate"
         assert config.use_grouped_mm is False
-        assert config.grouped_mm_backend == "sequential"
         assert config.route_norm is True
         assert config.route_scale == 2.0
         assert config.score_apply == "pre"
@@ -495,22 +492,18 @@ class TestGroupedExperts:
         assert experts.w2.grad is not None and experts.w2.grad.abs().sum() > 0
         assert experts.w3.grad is not None and experts.w3.grad.abs().sum() > 0
 
-    def test_grouped_mm_fallback_when_unavailable(self):
-        # Mock torch._grouped_mm as unavailable
-        original = getattr(torch, '_grouped_mm', None)
+    def test_grouped_mm_raises_when_unavailable(self):
+        original = getattr(torch, "_grouped_mm", None)
         try:
-            if hasattr(torch, '_grouped_mm'):
-                delattr(torch, '_grouped_mm')
-            experts = GroupedExperts(dim=64, hidden_dim=128, num_experts=4, use_grouped_mm=True)
-            assert experts.use_grouped_mm is False  # Should have fallen back
+            if hasattr(torch, "_grouped_mm"):
+                delattr(torch, "_grouped_mm")
+            with pytest.raises(RuntimeError, match=r"torch\._grouped_mm"):
+                GroupedExperts(dim=64, hidden_dim=128, num_experts=4, use_grouped_mm=True)
+            experts = GroupedExperts(dim=64, hidden_dim=128, num_experts=4, use_grouped_mm=False)
+            assert experts.use_grouped_mm is False
         finally:
             if original is not None:
                 torch._grouped_mm = original
-
-    def test_cutlass_backend_raises_not_implemented(self):
-        # Test that cutlass raises NotImplementedError if requested
-        # This is tested via the backend attribute, not constructor
-        pass  # CUTLASS path is out of scope for Phase 2
 
 
 class TestTokenReorderer:


### PR DESCRIPTION
This PR is a reviewable patch branch for AutoEP PR #7938, targeting the private staging branch `codex/autoep-pr7938-staging` in `tohtana/DeepSpeed` only.

It is intentionally not opened against `deepspeedai/DeepSpeed`.

Source tracking:
- dev_ds TODO: tohtana/dev_ds#86 / PR https://github.com/tohtana/dev_ds/pull/96
- Upstream baseline: deepspeedai/DeepSpeed#7938 head `5af8e41da0f5cf4656a1d5641a9268e81277dd57`
- Local patch source: `/mnt/user_storage/dev_ds_worktrees/autoep-pr7938-review/remove-autoep-grouped-mm-backend/DeepSpeed`

Validation already captured in the corresponding dev_ds artifacts. This PR is for GitHub review and controlled staging-branch merge.
