### PR TITLE
AutoEP: align supported presets and add Qwen3.5 guard

### DIFF
--- a/deepspeed/module_inject/auto_ep.py
+++ b/deepspeed/module_inject/auto_ep.py
@@ -10,6 +10,7 @@ Phase 5: Layer replacement (replace_moe_layer filled in).
 
 from __future__ import annotations
 
+import importlib.util
 import re
 from typing import Literal
 
@@ -24,6 +25,21 @@ from deepspeed.module_inject.auto_ep_config import (
     PRESET_MODELS,
     _UNSET,
 )
+
+_QWEN3_5_MOE_REQUIREMENT = {
+    "module": "transformers.models.qwen3_5_moe",
+    "classes": (
+        "Qwen3_5MoeConfig",
+        "Qwen3_5MoeTextConfig",
+        "Qwen3_5MoeModel",
+        "Qwen3_5MoeForCausalLM",
+        "Qwen3_5MoeForConditionalGeneration",
+    ),
+    "model_type_classes": {
+        "qwen3_5_moe": "Qwen3_5MoeConfig",
+        "qwen3_5_moe_text": "Qwen3_5MoeTextConfig",
+    },
+}
 
 
 def _remove_transformers_output_capture_hooks(model: nn.Module) -> int:
@@ -535,12 +551,77 @@ class AutoEP:
         from dataclasses import replace
         return replace(preset, **overrides)
 
+    def _qwen3_5_transformers_availability(self) -> tuple[str | None, list[str], list[str], list[str], str | None]:
+        """Return installed Transformers availability for Qwen3.5 MoE support."""
+        try:
+            import transformers
+        except Exception as exc:
+            return None, list(_QWEN3_5_MOE_REQUIREMENT["classes"]), [
+                _QWEN3_5_MOE_REQUIREMENT["module"]
+            ], list(_QWEN3_5_MOE_REQUIREMENT["model_type_classes"]), str(exc)
+
+        version = getattr(transformers, "__version__", "unknown")
+        missing_classes = [name for name in _QWEN3_5_MOE_REQUIREMENT["classes"] if not hasattr(transformers, name)]
+        module_name = _QWEN3_5_MOE_REQUIREMENT["module"]
+        missing_modules = [] if importlib.util.find_spec(module_name) is not None else [module_name]
+
+        missing_model_types = []
+        for model_type, class_name in _QWEN3_5_MOE_REQUIREMENT["model_type_classes"].items():
+            config_cls = getattr(transformers, class_name, None)
+            if config_cls is None or getattr(config_cls, "model_type", None) != model_type:
+                missing_model_types.append(model_type)
+
+        return version, missing_classes, missing_modules, missing_model_types, None
+
+    def _validate_qwen3_5_transformers_available(self, requested_model_type: str | None = None) -> None:
+        version, missing_classes, missing_modules, missing_model_types, import_error = \
+            self._qwen3_5_transformers_availability()
+        if not (missing_classes or missing_modules or missing_model_types or import_error):
+            return
+
+        details = []
+        if import_error:
+            details.append(f"could not import transformers: {import_error}")
+        if missing_classes:
+            details.append(f"missing class(es): {', '.join(missing_classes)}")
+        if missing_modules:
+            details.append(f"missing module(s): {', '.join(missing_modules)}")
+        if missing_model_types:
+            details.append(f"missing model_type registration(s): {', '.join(missing_model_types)}")
+
+        model_type_msg = f" for model_type='{requested_model_type}'" if requested_model_type else ""
+        version_msg = f" (installed transformers=={version})" if version else ""
+        raise ValueError("AutoEP preset 'qwen3_5_moe'"
+                         f"{model_type_msg} requires a Hugging Face Transformers build with Qwen3.5 MoE support"
+                         f"{version_msg}, but the installed package is not compatible: {'; '.join(details)}. "
+                         "Upgrade Transformers or use an AutoEP preset/model supported by the installed "
+                         "Transformers version.")
+
+    def _raise_unsupported_qwen3_5_model_type(self, model_type: str) -> None:
+        try:
+            self._validate_qwen3_5_transformers_available(model_type)
+        except ValueError as exc:
+            raise ValueError(
+                f"AutoEP preset 'qwen3_5_moe' supports the Qwen3.5 text backbone model_type "
+                f"'qwen3_5_moe_text', but got model_type='{model_type}'. {exc}"
+            ) from exc
+
+        raise ValueError("AutoEP preset 'qwen3_5_moe' supports the Qwen3.5 text backbone model_type "
+                         f"'qwen3_5_moe_text', but got model_type='{model_type}'. Use a Qwen3.5 text "
+                         "model/backbone for AutoEP, or choose a preset/model combination supported by the "
+                         "installed Transformers version.")
+
     def _resolve_presets(self) -> list[tuple[str, MoEModelPreset]]:
         """Determine which preset(s) to use for detection."""
         if self.config.preset_model is not None:
             if self.config.preset_model not in PRESET_MODELS:
                 raise ValueError(f"Unknown preset_model '{self.config.preset_model}'. "
                                  f"Available: {list(PRESET_MODELS.keys())}")
+            if self.config.preset_model == "qwen3_5_moe":
+                model_type = getattr(self.model_config, "model_type", None)
+                if model_type == "qwen3_5_moe":
+                    self._raise_unsupported_qwen3_5_model_type(model_type)
+                self._validate_qwen3_5_transformers_available(model_type)
             preset = self._apply_config_overrides(PRESET_MODELS[self.config.preset_model])
             return [(self.config.preset_model, preset)]
 
@@ -548,6 +629,8 @@ class AutoEP:
         if self.model_config is not None:
             model_type = getattr(self.model_config, 'model_type', None)
             if model_type:
+                if model_type == 'qwen3_5_moe':
+                    self._raise_unsupported_qwen3_5_model_type(model_type)
                 # Map HF model_type to preset name
                 type_map = {
                     'mixtral': 'mixtral',
@@ -561,6 +644,8 @@ class AutoEP:
                 }
                 preset_name = type_map.get(model_type)
                 if preset_name and preset_name in PRESET_MODELS:
+                    if preset_name == "qwen3_5_moe":
+                        self._validate_qwen3_5_transformers_available(model_type)
                     logger.info(f"AutoEP: auto-detected model_type='{model_type}', using preset '{preset_name}'")
                     preset = self._apply_config_overrides(PRESET_MODELS[preset_name])
                     return [(preset_name, preset)]

--- a/deepspeed/module_inject/auto_ep.py
+++ b/deepspeed/module_inject/auto_ep.py
@@ -41,6 +41,17 @@ _QWEN3_5_MOE_REQUIREMENT = {
     },
 }
 
+_AUTOEP_MODEL_TYPE_PRESETS = {
+    'mixtral': 'mixtral',
+    'qwen3_moe': 'qwen3_moe',
+    'qwen2_moe': 'qwen2_moe',
+    'qwen3_5_moe_text': 'qwen3_5_moe',
+    'deepseek_v2': 'deepseek_v2',
+    'deepseek_v3': 'deepseek_v3',
+    'llama4': 'llama4',
+    'llama4_text': 'llama4',
+}
+
 
 def _remove_transformers_output_capture_hooks(model: nn.Module) -> int:
     """Remove HF output-capturing hooks so they can be reinstalled after AutoEP conversion."""
@@ -427,6 +438,8 @@ class AutoEP:
                              f"experts={num_experts}, top_k={top_k}, storage={storage})")
 
         if not specs:
+            if self._requires_selected_preset_detection():
+                self._raise_no_moe_layers_detected(presets_to_try)
             logger.warning("AutoEP: no MoE layers detected in model.")
 
         return specs
@@ -551,6 +564,11 @@ class AutoEP:
         from dataclasses import replace
         return replace(preset, **overrides)
 
+    # Qwen3.5 is stricter than the other presets because this path depends on
+    # the HF text-backbone model_type and OutputRecorder retargeting contract.
+    # Other presets can be supplied by compatible custom/trust_remote_code model
+    # classes, so they rely on structural detection errors instead of class
+    # import checks.
     def _qwen3_5_transformers_availability(self) -> tuple[str | None, list[str], list[str], list[str], str | None]:
         """Return installed Transformers availability for Qwen3.5 MoE support."""
         try:
@@ -611,6 +629,33 @@ class AutoEP:
                          "model/backbone for AutoEP, or choose a preset/model combination supported by the "
                          "installed Transformers version.")
 
+    def _requires_selected_preset_detection(self) -> bool:
+        """Return whether empty detection should fail for the selected preset."""
+        if self.config.preset_model is not None:
+            return True
+        if self.model_config is None:
+            return False
+        model_type = getattr(self.model_config, 'model_type', None)
+        return bool(model_type and model_type in _AUTOEP_MODEL_TYPE_PRESETS)
+
+    def _raise_no_moe_layers_detected(self, presets_to_try: list[tuple[str, MoEModelPreset]]) -> None:
+        model_type = getattr(self.model_config, 'model_type', None)
+        if self.config.preset_model is not None:
+            source = f"preset_model='{self.config.preset_model}'"
+        else:
+            source = f"model_type='{model_type}'"
+
+        expected = "; ".join(
+            f"{preset_name}: moe_layer_pattern='{preset.moe_layer_pattern}', "
+            f"router='{preset.router_pattern}', experts='{preset.experts_pattern}'"
+            for preset_name, preset in presets_to_try)
+        raise ValueError(
+            f"AutoEP: no MoE layers detected for {source}. "
+            f"Expected MoE structure for selected preset(s): {expected}. "
+            "This usually means the selected preset does not match the model implementation, "
+            "or the installed Transformers version exposes a different structure. Choose a matching "
+            "preset, upgrade Transformers, or provide custom AutoEP patterns.")
+
     def _resolve_presets(self) -> list[tuple[str, MoEModelPreset]]:
         """Determine which preset(s) to use for detection."""
         if self.config.preset_model is not None:
@@ -632,17 +677,7 @@ class AutoEP:
                 if model_type == 'qwen3_5_moe':
                     self._raise_unsupported_qwen3_5_model_type(model_type)
                 # Map HF model_type to preset name
-                type_map = {
-                    'mixtral': 'mixtral',
-                    'qwen3_moe': 'qwen3_moe',
-                    'qwen2_moe': 'qwen2_moe',
-                    'qwen3_5_moe_text': 'qwen3_5_moe',
-                    'deepseek_v2': 'deepseek_v2',
-                    'deepseek_v3': 'deepseek_v3',
-                    'llama4': 'llama4',
-                    'llama4_text': 'llama4',
-                }
-                preset_name = type_map.get(model_type)
+                preset_name = _AUTOEP_MODEL_TYPE_PRESETS.get(model_type)
                 if preset_name and preset_name in PRESET_MODELS:
                     if preset_name == "qwen3_5_moe":
                         self._validate_qwen3_5_transformers_available(model_type)

--- a/deepspeed/module_inject/auto_ep_config.py
+++ b/deepspeed/module_inject/auto_ep_config.py
@@ -172,7 +172,7 @@ PRESET_MODELS: dict[str, MoEModelPreset] = {
         has_shared_experts=True,
         shared_experts_pattern="shared_expert",
         shared_experts_gate_pattern="shared_expert_gate",
-        hf_model_types=("qwen3_moe", ),
+        hf_model_types=("qwen3_moe", "qwen2_moe"),
         min_transformers_version="5.0.0",
         docs_support_notes=("Also covers Qwen2-MoE when the installed Transformers build uses the "
                             "validated fused expert layout."),

--- a/deepspeed/module_inject/auto_ep_preset_adapters.py
+++ b/deepspeed/module_inject/auto_ep_preset_adapters.py
@@ -101,6 +101,8 @@ class AutoEPPresetAdapter:
         return getattr(transformers, "__version__", "unknown")
 
     def _requires_transformers_version_validation(self) -> bool:
+        # The default adapter also covers non-HF/mock/custom-compatible configs;
+        # specialized HF-only adapters opt in to minimum Transformers checks.
         return False
 
     def resolve_route_norm(

--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -891,7 +891,14 @@ Configure AutoEP expert parallelism for MoE models. AutoEP automatically detects
 
 | Description                                                                                                                            | Default |
 | -------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| Built-in model preset for MoE detection: `mixtral`, `qwen3_moe`, `deepseek_v2`, `deepseek_v3`, `llama4`. Determines router, expert, and weight naming patterns. | `null`  |
+| Built-in model preset for MoE detection: `mixtral`, `qwen2_moe`, `qwen3_moe`, `qwen3_5_moe`, `deepseek_v2`, `deepseek_v3`, `llama4`. Determines router, expert, and weight naming patterns. | `null`  |
+
+Built-in AutoEP presets describe DeepSpeed's router/expert/weight-pattern support for a model family.
+Running a HuggingFace model also requires the installed Transformers package to expose the corresponding
+config/model classes and `model.config.model_type` value. For example, `qwen3_5_moe` is an AutoEP preset,
+but Qwen3.5-MoE models require a Transformers build with Qwen3.5-MoE support, including the
+`qwen3_5_moe` and `qwen3_5_moe_text` model types. Upgrade Transformers or select a preset/model supported
+by the installed Transformers version if those classes or model types are unavailable.
 
 ***use_grouped_mm***: [boolean]
 

--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -895,10 +895,22 @@ Configure AutoEP expert parallelism for MoE models. AutoEP automatically detects
 
 Built-in AutoEP presets describe DeepSpeed's router/expert/weight-pattern support for a model family.
 Running a HuggingFace model also requires the installed Transformers package to expose the corresponding
-config/model classes and `model.config.model_type` value. For example, `qwen3_5_moe` is an AutoEP preset,
-but Qwen3.5-MoE models require a Transformers build with Qwen3.5-MoE support, including the
-`qwen3_5_moe` and `qwen3_5_moe_text` model types. Upgrade Transformers or select a preset/model supported
-by the installed Transformers version if those classes or model types are unavailable.
+config/model classes, `model.config.model_type` value, and fused expert layout. The tiny HuggingFace
+smoke coverage used for this AutoEP surface produced the following version gates:
+
+| Preset | Minimum Transformers version | Smoke status | Notes |
+| ------ | ---------------------------- | ------------ | ----- |
+| `mixtral` | `5.0.0` | Forward parity | `4.48.0` through `4.57.6` expose classes but do not match the fused expert layout. |
+| `qwen2_moe` | `5.0.0` | Forward parity | `4.48.0` through `4.57.6` expose Qwen2-MoE classes but use a structure AutoEP does not detect with this preset. |
+| `qwen3_moe` | `5.0.0` | Forward parity | Qwen3-MoE classes appear in `4.51.3`, but `4.x` builds tested here do not match the fused expert layout. |
+| `qwen3_5_moe` | `5.2.0` | Forward parity | Requires the Qwen3.5 text-backbone `qwen3_5_moe_text` model type; earlier builds tested here do not expose the required classes. |
+| `deepseek_v2` | `5.0.0` | Replace | `4.54.1` and `4.57.6` expose classes but do not match the preset; forward parity was not established by this smoke. |
+| `deepseek_v3` | `5.0.0` | Replace | `4.51.3` through `4.57.6` expose classes but do not match the preset; forward parity was not established by this smoke. |
+| `llama4` | `5.0.0` | Forward parity | Some `4.x` builds pass the tiny smoke, but `4.51.3` and `4.54.1` did not; use `5.0.0` or newer for the validated path. |
+
+`Forward parity` means a one-layer CPU CausalLM smoke matched native HuggingFace logits and loss after
+AutoEP replacement. `Replace` means detection and replacement succeeded, but this smoke did not establish
+end-to-end forward parity.
 
 ***use_grouped_mm***: [boolean]
 

--- a/docs/code-docs/source/moe.rst
+++ b/docs/code-docs/source/moe.rst
@@ -19,14 +19,58 @@ pattern of AutoTP (Automatic Tensor Parallelism).
 (LLaMA-4).
 
 The preset name means AutoEP knows the router, expert, and weight naming
-patterns for that model family. Running a HuggingFace model still requires an
-installed Transformers build that exposes the corresponding config/model
-classes and ``model.config.model_type`` value. For example, the
-``qwen3_5_moe`` preset is available in AutoEP, but Qwen3.5-MoE models require
-Transformers Qwen3.5-MoE support, including the ``qwen3_5_moe`` and
-``qwen3_5_moe_text`` config model types; older Transformers builds that do not
-expose those classes must be upgraded or used with another supported
-preset/model.
+patterns for that model family. Running a HuggingFace model also requires a
+Transformers build that exposes the matching config/model classes,
+``model.config.model_type`` value, and fused expert layout.
+
+The compatibility table below records the tiny HuggingFace smoke coverage used
+for this AutoEP surface. ``Forward parity`` means a one-layer CPU CausalLM smoke
+matched native HuggingFace logits and loss after AutoEP replacement. ``Replace``
+means detection and replacement succeeded, but this smoke did not establish
+end-to-end forward parity.
+
+.. list-table:: AutoEP preset compatibility by Transformers version
+   :header-rows: 1
+
+   * - Preset
+     - Minimum Transformers version
+     - Smoke status
+     - Notes
+   * - ``mixtral``
+     - ``5.0.0``
+     - Forward parity
+     - ``4.48.0`` through ``4.57.6`` expose the classes but do not match the
+       preset's fused expert layout.
+   * - ``qwen2_moe``
+     - ``5.0.0``
+     - Forward parity
+     - ``4.48.0`` through ``4.57.6`` expose Qwen2-MoE classes but use a
+       structure that AutoEP does not detect with this preset.
+   * - ``qwen3_moe``
+     - ``5.0.0``
+     - Forward parity
+     - Qwen3-MoE classes appear in ``4.51.3``, but ``4.x`` builds tested here
+       do not match the preset's fused expert layout.
+   * - ``qwen3_5_moe``
+     - ``5.2.0``
+     - Forward parity
+     - Requires the Qwen3.5 text-backbone ``qwen3_5_moe_text`` model type;
+       earlier builds tested here do not expose the required classes.
+   * - ``deepseek_v2``
+     - ``5.0.0``
+     - Replace
+     - ``4.54.1`` and ``4.57.6`` expose classes but do not match the preset;
+       forward parity was not established by this smoke.
+   * - ``deepseek_v3``
+     - ``5.0.0``
+     - Replace
+     - ``4.51.3`` through ``4.57.6`` expose classes but do not match the
+       preset; forward parity was not established by this smoke.
+   * - ``llama4``
+     - ``5.0.0``
+     - Forward parity
+     - Some ``4.x`` builds pass the tiny smoke, but ``4.51.3`` and ``4.54.1``
+       did not; use ``5.0.0`` or newer for the validated path.
 
 **ZeRO compatibility:** Stages 0, 1, and 2. Stage 3 is not supported.
 

--- a/docs/code-docs/source/moe.rst
+++ b/docs/code-docs/source/moe.rst
@@ -13,8 +13,20 @@ AutoEP automatically detects MoE layers in HuggingFace models and replaces them
 with EP-enabled versions, requiring zero model code changes. It follows the
 pattern of AutoTP (Automatic Tensor Parallelism).
 
-**Supported models:** Mixtral, Qwen3-MoE, DeepSeek-V2, DeepSeek-V3, LLaMA-4
-(via built-in presets).
+**Built-in AutoEP presets:** ``mixtral`` (Mixtral), ``qwen2_moe`` (Qwen2-MoE),
+``qwen3_moe`` (Qwen3-MoE), ``qwen3_5_moe`` (Qwen3.5-MoE),
+``deepseek_v2`` (DeepSeek-V2), ``deepseek_v3`` (DeepSeek-V3), and ``llama4``
+(LLaMA-4).
+
+The preset name means AutoEP knows the router, expert, and weight naming
+patterns for that model family. Running a HuggingFace model still requires an
+installed Transformers build that exposes the corresponding config/model
+classes and ``model.config.model_type`` value. For example, the
+``qwen3_5_moe`` preset is available in AutoEP, but Qwen3.5-MoE models require
+Transformers Qwen3.5-MoE support, including the ``qwen3_5_moe`` and
+``qwen3_5_moe_text`` config model types; older Transformers builds that do not
+expose those classes must be upgraded or used with another supported
+preset/model.
 
 **ZeRO compatibility:** Stages 0, 1, and 2. Stage 3 is not supported.
 

--- a/tests/unit/moe/test_autoep_unit.py
+++ b/tests/unit/moe/test_autoep_unit.py
@@ -332,7 +332,7 @@ class TestAutoEPConfig:
         assert qwen3.has_shared_experts is True
         assert qwen3.shared_experts_pattern == "shared_expert"
         assert qwen3.shared_experts_gate_pattern == "shared_expert_gate"
-        assert qwen3.hf_model_types == ("qwen3_moe", )
+        assert qwen3.hf_model_types == ("qwen3_moe", "qwen2_moe")
         assert qwen3.min_transformers_version == "5.0.0"
         assert "Qwen2-MoE" in qwen3.docs_support_notes
 
@@ -922,6 +922,25 @@ class TestMoEDetection:
 
         assert len(presets) == 1
         assert presets[0][0] == "qwen3_5_moe"
+
+    def test_auto_detect_qwen2_model_type_uses_qwen3_preset(self):
+        """model_type='qwen2_moe' resolves through qwen3_moe metadata."""
+        model = MockMoETransformer(num_layers=1, moe_every_n=1)
+        model.config.model_type = "qwen2_moe"
+        model.config.num_experts = model.config.num_local_experts
+        config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+        })
+
+        auto_ep = AutoEP(model, config)
+        presets = auto_ep._resolve_presets()
+        specs = auto_ep.ep_parser()
+
+        assert len(presets) == 1
+        assert presets[0][0] == "qwen3_moe"
+        assert len(specs) == 1
+        assert specs[0].model_family == "qwen3_moe"
 
     def test_auto_detected_preset_delegates_compatibility_validation(self, monkeypatch):
         """Generic model_type detection calls the preset adapter validation hook."""

--- a/tests/unit/moe/test_autoep_unit.py
+++ b/tests/unit/moe/test_autoep_unit.py
@@ -715,6 +715,45 @@ class TestMoEDetection:
         module_names = [s.moe_module_name for s in specs]
         assert "model.layers.1.mlp" not in module_names
 
+    def test_explicit_preset_without_matching_moe_layers_fails_actionably(self):
+        """An explicit preset should not silently no-op when its structure is absent."""
+        model = MockMoETransformer(num_layers=1, moe_every_n=1)
+        config = AutoEPConfig(enabled=True, autoep_size=1, preset_model="llama4")
+
+        with pytest.raises(ValueError) as exc:
+            AutoEP(model, config).ep_parser()
+
+        message = str(exc.value)
+        assert "preset_model='llama4'" in message
+        assert "no MoE layers detected" in message
+        assert "moe_layer_pattern" in message
+        assert "Transformers" in message
+
+    def test_auto_detected_preset_without_matching_moe_layers_fails_actionably(self):
+        """A known model_type selects one preset, so empty detection is actionable."""
+
+        class DenseOnlyTransformer(nn.Module):
+
+            def __init__(self):
+                super().__init__()
+                self.config = MockHFConfig()
+                self.model = nn.Module()
+                layer = nn.Module()
+                layer.mlp = MockDenseBlock()
+                self.model.layers = nn.ModuleList([layer])
+
+        model = DenseOnlyTransformer()
+        config = AutoEPConfig(enabled=True, autoep_size=1)
+
+        with pytest.raises(ValueError) as exc:
+            AutoEP(model, config).ep_parser()
+
+        message = str(exc.value)
+        assert "model_type='mixtral'" in message
+        assert "mixtral" in message
+        assert "no MoE layers detected" in message
+        assert "moe_layer_pattern" in message
+
     def test_detect_fused_3d_storage(self):
         """Correctly identifies fused_3d expert storage."""
         model = MockMoETransformer(num_layers=2, moe_every_n=1)
@@ -1331,7 +1370,12 @@ class TestAutoEPMoELayerUnit:
             "use_grouped_mm": False,
         })
         auto_ep = AutoEP(autoep_model, autoep_config)
-        specs = auto_ep.ep_parser()
+        try:
+            specs = auto_ep.ep_parser()
+        except ValueError as exc:
+            if "no MoE layers detected" in str(exc):
+                pytest.skip(f"Installed transformers Qwen2 MoE structure is not compatible with AutoEP: {exc}")
+            raise
         assert len(specs) == 1
         assert specs[0].model_family == "qwen2_moe"
         assert specs[0].has_shared_experts is True

--- a/tests/unit/moe/test_autoep_unit.py
+++ b/tests/unit/moe/test_autoep_unit.py
@@ -7,6 +7,8 @@
 import copy
 from pathlib import Path
 
+from packaging.version import Version
+
 import pytest
 import torch
 import torch.nn as nn
@@ -1338,6 +1340,8 @@ class TestAutoEPMoELayerUnit:
         transformers = pytest.importorskip("transformers")
         if not hasattr(transformers, "Qwen2MoeConfig") or not hasattr(transformers, "Qwen2MoeForCausalLM"):
             pytest.skip("Installed transformers does not expose Qwen2MoeConfig/Qwen2MoeForCausalLM")
+        if Version(transformers.__version__) < Version("5.0.0"):
+            pytest.skip("Qwen2 MoE AutoEP preset requires Transformers >= 5.0.0 for the fused expert layout")
 
         torch.manual_seed(1234)
         config = transformers.Qwen2MoeConfig(
@@ -1370,12 +1374,7 @@ class TestAutoEPMoELayerUnit:
             "use_grouped_mm": False,
         })
         auto_ep = AutoEP(autoep_model, autoep_config)
-        try:
-            specs = auto_ep.ep_parser()
-        except ValueError as exc:
-            if "no MoE layers detected" in str(exc):
-                pytest.skip(f"Installed transformers Qwen2 MoE structure is not compatible with AutoEP: {exc}")
-            raise
+        specs = auto_ep.ep_parser()
         assert len(specs) == 1
         assert specs[0].model_family == "qwen2_moe"
         assert specs[0].has_shared_experts is True
@@ -1403,6 +1402,8 @@ class TestAutoEPMoELayerUnit:
         transformers = pytest.importorskip("transformers")
         if not hasattr(transformers, "Qwen3MoeConfig") or not hasattr(transformers, "Qwen3MoeForCausalLM"):
             pytest.skip("Installed transformers does not expose Qwen3MoeConfig/Qwen3MoeForCausalLM")
+        if Version(transformers.__version__) < Version("5.0.0"):
+            pytest.skip("Qwen3 MoE AutoEP preset requires Transformers >= 5.0.0 for the fused expert layout")
 
         torch.manual_seed(1234)
         config = transformers.Qwen3MoeConfig(
@@ -1463,6 +1464,8 @@ class TestAutoEPMoELayerUnit:
         transformers = pytest.importorskip("transformers")
         required = ("Qwen3_5MoeTextConfig", "Qwen3_5MoeForCausalLM")
         missing = [name for name in required if not hasattr(transformers, name)]
+        if Version(transformers.__version__) < Version("5.2.0"):
+            pytest.skip("Qwen3.5 MoE AutoEP preset requires Transformers >= 5.2.0")
         if missing:
             pytest.skip(f"Installed transformers does not expose Qwen3.5 MoE classes: {missing}")
 
@@ -1528,6 +1531,8 @@ class TestAutoEPMoELayerUnit:
         if not hasattr(transformers, "Llama4ForCausalLM") or not hasattr(transformers, "Llama4TextConfig"):
             pytest.skip("Installed transformers does not expose Llama4ForCausalLM/Llama4TextConfig")
 
+        if Version(transformers.__version__) < Version("5.0.0"):
+            pytest.skip("Llama4 AutoEP preset is validated against Transformers >= 5.0.0")
         torch.manual_seed(1234)
         config = transformers.Llama4TextConfig(
             vocab_size=64,
@@ -1588,6 +1593,8 @@ class TestAutoEPMoELayerUnit:
         if not hasattr(transformers, "Llama4ForCausalLM") or not hasattr(transformers, "Llama4TextConfig"):
             pytest.skip("Installed transformers does not expose Llama4ForCausalLM/Llama4TextConfig")
 
+        if Version(transformers.__version__) < Version("5.0.0"):
+            pytest.skip("Llama4 AutoEP preset is validated against Transformers >= 5.0.0")
         torch.manual_seed(1234)
         config = transformers.Llama4TextConfig(
             vocab_size=64,

--- a/tests/unit/moe/test_autoep_unit.py
+++ b/tests/unit/moe/test_autoep_unit.py
@@ -5,6 +5,7 @@
 """Unit tests for AutoEP feature (all phases append test classes here)."""
 
 import copy
+from pathlib import Path
 
 import pytest
 import torch
@@ -260,6 +261,19 @@ class TestAutoEPConfig:
             assert preset.score_func in ("softmax", "sigmoid")
             assert preset.score_apply in ("pre", "post")
 
+    def test_public_docs_list_all_autoep_presets(self):
+        """Public AutoEP docs list every built-in preset name."""
+        repo_root = Path(__file__).resolve().parents[3]
+        docs = [
+            repo_root / "docs" / "code-docs" / "source" / "moe.rst",
+            repo_root / "docs" / "_pages" / "config-json.md",
+        ]
+
+        for doc in docs:
+            text = doc.read_text(encoding="utf-8")
+            missing = sorted(name for name in PRESET_MODELS if name not in text)
+            assert not missing, f"{doc.relative_to(repo_root)} missing AutoEP preset(s): {missing}"
+
     def test_preset_field_values(self):
         """Spot-check Mixtral preset values."""
         mixtral = PRESET_MODELS["mixtral"]
@@ -282,6 +296,11 @@ class TestAutoEPConfig:
         assert qwen2.has_shared_experts is True
         assert qwen2.shared_experts_pattern == "shared_expert"
         assert qwen2.shared_experts_gate_pattern == "shared_expert_gate"
+
+        qwen35 = PRESET_MODELS["qwen3_5_moe"]
+        assert qwen35.has_shared_experts is True
+        assert qwen35.shared_experts_pattern == "shared_expert"
+        assert qwen35.shared_experts_gate_pattern == "shared_expert_gate"
 
     def test_validate_empty_expert_w1(self):
         """Empty expert_w1 raises ValueError."""
@@ -801,6 +820,58 @@ class TestMoEDetection:
         replaced = model.model.layers[0].feed_forward
         assert replaced.load_balance_coeff is None
         assert replaced.expert_bias is None
+
+    def test_auto_detect_qwen3_5_model_type_alias(self, monkeypatch):
+        """model_type='qwen3_5_moe_text' resolves to the qwen3_5_moe preset."""
+        model = MockMoETransformer(num_layers=1, moe_every_n=1)
+        model.config.model_type = "qwen3_5_moe_text"
+        model.config.num_experts = model.config.num_local_experts
+        config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+        })
+        monkeypatch.setattr(AutoEP, "_validate_qwen3_5_transformers_available", lambda self, model_type=None: None)
+
+        presets = AutoEP(model, config)._resolve_presets()
+
+        assert len(presets) == 1
+        assert presets[0][0] == "qwen3_5_moe"
+
+    def test_qwen3_5_missing_transformers_guard_names_requirement(self, monkeypatch):
+        """Qwen3.5 preset fails early when Transformers lacks the matching implementation."""
+        model = MockMoETransformer(num_layers=1, moe_every_n=1)
+
+        def missing_qwen35(_self):
+            return (
+                "4.48.0",
+                ["Qwen3_5MoeConfig", "Qwen3_5MoeForCausalLM"],
+                ["transformers.models.qwen3_5_moe"],
+                ["qwen3_5_moe_text"],
+                None,
+            )
+
+        monkeypatch.setattr(AutoEP, "_qwen3_5_transformers_availability", missing_qwen35)
+        config = AutoEPConfig(enabled=True, autoep_size=1, preset_model="qwen3_5_moe")
+
+        with pytest.raises(ValueError, match="qwen3_5_moe.*Qwen3_5MoeConfig.*qwen3_5_moe_text.*Upgrade"):
+            AutoEP(model, config)._resolve_presets()
+
+    def test_qwen3_5_top_level_model_type_fails_actionably(self, monkeypatch):
+        """Top-level Qwen3.5 multimodal model_type does not silently try every preset."""
+        model = MockMoETransformer(num_layers=1, moe_every_n=1)
+        model.config.model_type = "qwen3_5_moe"
+
+        def available_qwen35(_self):
+            return "5.0.0", [], [], [], None
+
+        monkeypatch.setattr(AutoEP, "_qwen3_5_transformers_availability", available_qwen35)
+        config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+        })
+
+        with pytest.raises(ValueError, match="qwen3_5_moe_text.*qwen3_5_moe.*supported"):
+            AutoEP(model, config)._resolve_presets()
 
     def test_replace_moe_layer_works(self):
         """replace_moe_layer creates AutoEPMoELayer replacement."""
@@ -1331,6 +1402,70 @@ class TestAutoEPMoELayerUnit:
         assert len(autoep_layers) == 1
         assert autoep_layers[0].shared_experts is None
         assert autoep_layers[0].shared_experts_gate is None
+
+        input_ids = torch.tensor([[1, 5, 7, 9, 11]], dtype=torch.long)
+        labels = input_ids.clone()
+        native_model.eval()
+        autoep_model.eval()
+        with torch.no_grad():
+            native_outputs = native_model(input_ids=input_ids, labels=labels, output_router_logits=False)
+            autoep_outputs = autoep_model(input_ids=input_ids, labels=labels, output_router_logits=False)
+
+        torch.testing.assert_close(autoep_outputs.logits, native_outputs.logits, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(autoep_outputs.loss, native_outputs.loss, rtol=1e-5, atol=1e-6)
+
+    def test_hf_qwen3_5_causal_lm_matches_autoep_when_transformers_supports_it(self):
+        """Tiny Qwen3.5 CausalLM AutoEP coverage is conditional on Transformers support."""
+        transformers = pytest.importorskip("transformers")
+        required = ("Qwen3_5MoeTextConfig", "Qwen3_5MoeForCausalLM")
+        missing = [name for name in required if not hasattr(transformers, name)]
+        if missing:
+            pytest.skip(f"Installed transformers does not expose Qwen3.5 MoE classes: {missing}")
+
+        torch.manual_seed(1234)
+        try:
+            config = transformers.Qwen3_5MoeTextConfig(
+                vocab_size=64,
+                hidden_size=32,
+                num_hidden_layers=1,
+                num_attention_heads=4,
+                num_key_value_heads=2,
+                max_position_embeddings=64,
+                moe_intermediate_size=16,
+                shared_expert_intermediate_size=32,
+                num_experts=4,
+                num_experts_per_tok=2,
+                output_router_logits=False,
+                tie_word_embeddings=False,
+                use_cache=False,
+                layer_types=["full_attention"],
+            )
+            native_model = transformers.Qwen3_5MoeForCausalLM(config)
+            autoep_model = transformers.Qwen3_5MoeForCausalLM(config)
+        except Exception as exc:
+            pytest.skip(f"Installed transformers Qwen3.5 MoE smoke setup is unavailable: {exc}")
+        autoep_model.load_state_dict(copy.deepcopy(native_model.state_dict()))
+
+        autoep_config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+            "preset_model": "qwen3_5_moe",
+            "use_grouped_mm": False,
+        })
+        auto_ep = AutoEP(autoep_model, autoep_config)
+        specs = auto_ep.ep_parser()
+        assert len(specs) == 1
+        assert specs[0].model_family == "qwen3_5_moe"
+        assert specs[0].has_shared_experts is True
+        assert specs[0].shared_experts_name == "shared_expert"
+        assert specs[0].shared_experts_gate_name == "shared_expert_gate"
+        for spec in specs:
+            auto_ep.replace_moe_layer(spec, ep_size=1, ep_rank=0)
+
+        autoep_layers = [module for module in autoep_model.modules() if isinstance(module, AutoEPMoELayer)]
+        assert len(autoep_layers) == 1
+        assert autoep_layers[0].shared_experts is not None
+        assert autoep_layers[0].shared_experts_gate is not None
 
         input_ids = torch.tensor([[1, 5, 7, 9, 11]], dtype=torch.long)
         labels = input_ids.clone()


### PR DESCRIPTION
This PR is a reviewable patch branch for AutoEP PR #7938, targeting the private staging branch `codex/autoep-pr7938-staging` in `tohtana/DeepSpeed` only.

It is intentionally not opened against `deepspeedai/DeepSpeed`.

Source tracking:
- dev_ds TODO: tohtana/dev_ds#87 / PR https://github.com/tohtana/dev_ds/pull/97
- Upstream baseline: deepspeedai/DeepSpeed#7938 head `5af8e41da0f5cf4656a1d5641a9268e81277dd57`
- Local patch source: `/mnt/user_storage/dev_ds_worktrees/autoep-pr7938-review/align-autoep-supported-presets-docs/DeepSpeed`

Validation already captured in the corresponding dev_ds artifacts. This PR is for GitHub review and controlled staging-branch merge.
