### PR TITLE
AutoEP: document Universal Checkpointing support

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -93,7 +93,7 @@ lnav:
         url: /tutorials/lrrt/
       - title: 'Megatron-LM GPT2'
         url: /tutorials/megatron/
-      - title: 'Mixture-of-Experts (MoE)'
+      - title: 'Mixture of Experts (DeepSpeed MoE)'
         url: /tutorials/mixture-of-experts/
       - title: 'MoE for NLG'
         url: /tutorials/mixture-of-experts-nlg/

--- a/docs/_pages/training.md
+++ b/docs/_pages/training.md
@@ -180,7 +180,7 @@ Below we provide a brief feature list, see our detailed [feature overview](https
   * Efficient and robust compressed training
   * Up to 2.5x convergence speedup for pre-training
 * [Performance Analysis and Debugging](https://www.deepspeed.ai/features/#performance-analysis-and-debugging)
-* [Mixture of Experts (MoE)](https://www.deepspeed.ai/tutorials/mixture-of-experts/)
+* [Mixture of Experts (DeepSpeed MoE)](https://www.deepspeed.ai/tutorials/mixture-of-experts/)
 
 
 ---

--- a/docs/_tutorials/mixture-of-experts.md
+++ b/docs/_tutorials/mixture-of-experts.md
@@ -1,5 +1,5 @@
 ---
-title: "Mixture of Experts"
+title: "Mixture of Experts (DeepSpeed MoE)"
 tags: MoE training
 ---
 

--- a/docs/_tutorials/universal-checkpointing.md
+++ b/docs/_tutorials/universal-checkpointing.md
@@ -58,6 +58,28 @@ metadata (`UNIVERSAL_CHECKPOINT_INFO`) to reconstruct tensor-parallel parameters
 correctly, including row-parallel, column-parallel, replicated, fused, and
 sub-parameter layouts.
 
+### Step 3: Resume Training with Universal Checkpoint
+
+With the Universal checkpoint ready, resume training by enabling Universal
+Checkpoint loading in your DeepSpeed config:
+
+```json
+{
+  "checkpoint": {
+    "load_universal": true
+  }
+}
+```
+
+Then load the converted checkpoint through the normal DeepSpeed checkpoint API:
+
+```python
+engine.load_checkpoint("/path/to/universal_checkpoint", tag=tag)
+```
+
+The target run still needs the DeepSpeed parallelism configuration that matches
+the model and topology you want to use for resumed training.
+
 ### AutoEP Requirements and Limitations
 
 AutoEP checkpoints are saved as regular DeepSpeed checkpoints, but routed expert
@@ -133,28 +155,6 @@ Additional AutoEP failure cases:
   expert optimizer shards. If `expp_rank_*_mp_rank_*_optim_states.pt` files or
   matching state entries are absent, the converter still writes the model
   parameter `fp32.pt` files and skips unavailable optimizer state files.
-
-### Step 3: Resume Training with Universal Checkpoint
-
-With the Universal checkpoint ready, resume training by enabling Universal
-Checkpoint loading in your DeepSpeed config:
-
-```json
-{
-  "checkpoint": {
-    "load_universal": true
-  }
-}
-```
-
-Then load the converted checkpoint through the normal DeepSpeed checkpoint API:
-
-```python
-engine.load_checkpoint("/path/to/universal_checkpoint", tag=tag)
-```
-
-The target run still needs the DeepSpeed parallelism configuration that matches
-the model and topology you want to use for resumed training.
 
 
 ## Conclusion

--- a/docs/_tutorials/universal-checkpointing.md
+++ b/docs/_tutorials/universal-checkpointing.md
@@ -152,6 +152,7 @@ Current limits and failure cases:
 
 - ZeRO Stage 3 AutoEP Universal Checkpoint conversion is not supported. When AutoEP metadata is present, the converter raises `NotImplementedError` with the message that "AutoEP currently requires ZeRO Stage 1 or 2."
 - For ZeRO Stage 1 and ZeRO Stage 2 conversion, expert checkpoint files without `ds_autoep_layers` / `autoep_layers` metadata raise a `RuntimeError`.
+- Existing DeepSpeed MoE or Megatron-DeepSpeed expert checkpoint files may share the `layer_<moe_layer_id>_expert_<global_expert_id>_mp_rank_<NN>_model_states.pt` naming convention, but they use native `deepspeed_moe` expert parameter names and do not carry AutoEP metadata. Loading or converting those checkpoints into AutoEP requires a separate model-specific migration step.
 - If AutoEP metadata is present but an expected per-expert model file is missing, conversion raises `FileNotFoundError`.
 - More than one `mp_rank_*` expert file for the same `(layer, expert)` pair raises `NotImplementedError`; combined AutoEP + AutoTP topology changes are not documented by this path.
 - AutoEP optimizer-state consolidation is best effort. It succeeds for the usual ZeRO Stage 1 / 2 AutoEP training checkpoints that include matching expert optimizer shards. If `expp_rank_*_mp_rank_*_optim_states.pt` files or matching state entries are absent, the converter still writes the model parameter `fp32.pt` files and skips unavailable optimizer state files.

--- a/docs/_tutorials/universal-checkpointing.md
+++ b/docs/_tutorials/universal-checkpointing.md
@@ -90,6 +90,73 @@ python deepspeed/checkpoint/ds_to_universal.py \
 ```
 
 
+## Universal Checkpointing with AutoEP (Automatic Expert Parallelism)
+
+AutoEP checkpoints are saved as regular DeepSpeed checkpoints. With AutoEP enabled, DeepSpeed writes the routed expert weights (`w1`, `w2`, and `w3`) into per-expert files named like `layer_<moe_layer_id>_expert_<global_expert_id>_mp_rank_<NN>_model_states.pt`. The regular model checkpoint records AutoEP metadata in `ds_autoep_layers`; older checkpoints may use the legacy `autoep_layers` key. Router, gate, shared-expert, and other non-routed-expert parameters stay in the regular `mp_rank_*_model_states.pt` files and use the standard Universal Checkpointing path.
+
+Use ZeRO Stage 1 or ZeRO Stage 2 for the current AutoEP Universal Checkpoint conversion path:
+
+```json
+{
+  "zero_optimization": { "stage": 2 },
+  "expert_parallel": {
+    "enabled": true,
+    "autoep_size": 4,
+    "preset_model": "mixtral"
+  }
+}
+```
+
+Save the checkpoint through the normal DeepSpeed API:
+
+```python
+engine.save_checkpoint(save_dir, tag=tag)
+```
+
+Regular AutoEP checkpoint load requires the target run to use the same `autoep_size` as the save run. To change `autoep_size` for the same AutoEP-detected model topology, convert the saved checkpoint to Universal Checkpoint format:
+
+```bash
+python deepspeed/checkpoint/ds_to_universal.py \
+  --input_folder /path/to/ds_checkpoint \
+  --output_folder /path/to/universal_checkpoint
+```
+
+During conversion, `ds_to_universal.py` reads `ds_autoep_layers` (or the legacy `autoep_layers` key), consolidates each AutoEP layer's routed expert files, and writes the full expert tensors to paths such as `zero/<expert_key_prefix>.w1/fp32.pt`. These files are tagged with `is_expert_param` and `ep_num_experts`, which are the load-time signals used for AutoEP expert resharding. When matching expert optimizer shards are available, the converter also writes optimizer state files such as `exp_avg.pt` and `exp_avg_sq.pt` next to the converted parameter.
+
+Load the converted checkpoint through the Universal Checkpoint path:
+
+```json
+{
+  "checkpoint": {
+    "load_universal": true
+  },
+  "expert_parallel": {
+    "enabled": true,
+    "autoep_size": 2,
+    "preset_model": "mixtral"
+  }
+}
+```
+
+```python
+engine.load_checkpoint("/path/to/universal_checkpoint", tag=tag)
+```
+
+In the Universal Checkpoint load path, AutoEP routed experts are restored from the `zero/` parameter layout rather than from the regular `layer_*_expert_*_model_states.pt` files. The target run's AutoEP process group supplies the load-side expert-parallel rank and size. For each tagged expert tensor, the loader slices the saved expert dimension by `ep_rank` and `ep_size` when `ep_size > 1`.
+
+The target model still needs to expose matching AutoEP parameter names and compatible shapes, for example `<module_path>.experts.w1`, `<module_path>.experts.w2`, and `<module_path>.experts.w3`. Universal Checkpointing changes the expert-parallel sharding for matching tensors; it does not translate between different model families, different module paths, or arbitrary expert parameter names. The target AutoEP configuration must also be valid before checkpoint loading, including `autoep_size` divisibility by the target stage size and by every detected target layer's expert count.
+
+Topology changes are limited to `autoep_size` resharding for matching AutoEP-managed expert parameters. For every AutoEP layer in the checkpoint, the saved `ep_num_experts` must be divisible by the target `autoep_size` when the target `ep_size > 1`. For example, an 8-expert checkpoint can load with target `autoep_size` values of 1, 2, 4, or 8, but not 3. With `autoep_size=1`, the expert tensor is not sliced, but the target parameter must still have the compatible full expert shape.
+
+Current limits and failure cases:
+
+- ZeRO Stage 3 AutoEP Universal Checkpoint conversion is not supported. When AutoEP metadata is present, the converter raises `NotImplementedError` with the message that "AutoEP currently requires ZeRO Stage 1 or 2."
+- For ZeRO Stage 1 and ZeRO Stage 2 conversion, expert checkpoint files without `ds_autoep_layers` / `autoep_layers` metadata raise a `RuntimeError`.
+- If AutoEP metadata is present but an expected per-expert model file is missing, conversion raises `FileNotFoundError`.
+- More than one `mp_rank_*` expert file for the same `(layer, expert)` pair raises `NotImplementedError`; combined AutoEP + AutoTP topology changes are not documented by this path.
+- AutoEP optimizer-state consolidation is best effort. It succeeds for the usual ZeRO Stage 1 / 2 AutoEP training checkpoints that include matching expert optimizer shards. If `expp_rank_*_mp_rank_*_optim_states.pt` files or matching state entries are absent, the converter still writes the model parameter `fp32.pt` files and skips unavailable optimizer state files.
+
+
 ## Conclusion
 DeepSpeed Universal Checkpointing simplifies the management of model states, making it easier to save, load, and transfer model states across different training sessions and parallelism techniques. By following the steps outlined in this tutorial, you can integrate Universal Checkpointing into your DeepSpeed applications, enhancing your model training and development workflow.
 

--- a/docs/_tutorials/universal-checkpointing.md
+++ b/docs/_tutorials/universal-checkpointing.md
@@ -18,102 +18,30 @@ Before you begin, ensure you have the following:
 
 ## How to use DeepSpeed Universal Checkpointing
 
-Follow the three simple steps below:
+Universal Checkpointing uses the same high-level flow for dense models, AutoTP
+(Automatic Tensor Parallelism), and AutoEP (Automatic Expert Parallelism): save a
+regular DeepSpeed ZeRO checkpoint, convert that checkpoint to Universal format,
+then load it with `checkpoint.load_universal` enabled.
 
 ### Step 1: Create ZeRO Checkpoint
 
-The first step in leveraging DeepSpeed Universal Checkpointing is to create a ZeRO checkpoint. [ZeRO](/tutorials/zero/) (Zero Redundancy Optimizer) is a memory optimization technology in DeepSpeed that allows for efficient training of large models. To create a ZeRO checkpoint, you'll need to:
-
- - Initialize your model with DeepSpeed using the ZeRO optimizer.
- - Train your model to the desired state (iterations).
- - Save a checkpoint using DeepSpeed's checkpointing feature.
-
-
-### Step 2: Convert ZeRO Checkpoint to Universal Format
-
-Once you have a ZeRO checkpoint, the next step is to convert it into the Universal format. This format is designed to be flexible and compatible across different model architectures and DeepSpeed configurations. To convert a checkpoint:
-
- - Use the [ds_to_universal.py](https://github.com/deepspeedai/DeepSpeed/blob/master/deepspeed/checkpoint/ds_to_universal.py) script provided by DeepSpeed.
- - Specify the path to your ZeRO checkpoint and the desired output path for the Universal checkpoint.
-
-```bash
-python ds_to_universal.py --input_folder /path/to/zero/checkpoint --output_folder /path/to/universal/checkpoint
-```
-
-This script will process the ZeRO checkpoint and generate a new checkpoint in the Universal format. Pass `--help` flag to see other options.
-
-### Step 3: Resume Training with Universal Checkpoint
-With the Universal checkpoint ready, you can now resume training on potentially with different parallelism topologies or training configurations. To do this add `--universal-checkpoint` to your DeepSpeed config (json) file
-
-
-## Universal Checkpointing with AutoTP (Automatic Tensor Parallelism)
-
-DeepSpeed AutoTP (Automatic Tensor Parallelism) can produce checkpoints that are compatible with Universal
-Checkpoint conversion and restore.
-
-### What gets saved
-
-When AutoTP is enabled, DeepSpeed will attach Universal Checkpoint metadata (`UNIVERSAL_CHECKPOINT_INFO`)
-to the saved training checkpoint. This metadata describes how tensor-parallel parameters were partitioned
-(e.g. row-parallel vs column-parallel, replicated parameters, and fused/sub-parameter layouts).
-
-This enables:
-- converting a TP-sharded training checkpoint into a Universal checkpoint via `ds_to_universal.py`
-- restoring the checkpoint correctly even when TP partitioning uses fused weights (e.g. QKV)
-
-### Enablement
-
-AutoTP is enabled by setting `tensor_parallel` in your DeepSpeed config:
-
-```json
-{
-  "zero_optimization": { "stage": 2 },
-  "bf16": { "enabled": true },
-  "tensor_parallel": { "autotp_size": 4 }
-}
-```
-
-Save a regular DeepSpeed checkpoint during training:
-
-```
-engine.save_checkpoint(save_dir, tag=tag)
-```
-
-### Conversion
-
-Convert the saved DeepSpeed checkpoint to the universal format:
-
-```
-python deepspeed/checkpoint/ds_to_universal.py \
-  --input_folder /path/to/ds_checkpoint \
-  --output_folder /path/to/universal_checkpoint
-```
-
-
-## Universal Checkpointing with AutoEP (Automatic Expert Parallelism)
-
-AutoEP checkpoints are saved as regular DeepSpeed checkpoints. With AutoEP enabled, DeepSpeed writes the routed expert weights (`w1`, `w2`, and `w3`) into per-expert files named like `layer_<moe_layer_id>_expert_<global_expert_id>_mp_rank_<NN>_model_states.pt`. The regular model checkpoint records AutoEP metadata in `ds_autoep_layers`; older checkpoints may use the legacy `autoep_layers` key. Router, gate, shared-expert, and other non-routed-expert parameters stay in the regular `mp_rank_*_model_states.pt` files and use the standard Universal Checkpointing path.
-
-Use ZeRO Stage 1 or ZeRO Stage 2 for the current AutoEP Universal Checkpoint conversion path:
-
-```json
-{
-  "zero_optimization": { "stage": 2 },
-  "expert_parallel": {
-    "enabled": true,
-    "autoep_size": 4,
-    "preset_model": "mixtral"
-  }
-}
-```
-
-Save the checkpoint through the normal DeepSpeed API:
+Start by creating a regular DeepSpeed checkpoint from a run that uses
+[ZeRO](/tutorials/zero/) (Zero Redundancy Optimizer). Use the normal DeepSpeed
+checkpoint API from your training script:
 
 ```python
 engine.save_checkpoint(save_dir, tag=tag)
 ```
 
-Regular AutoEP checkpoint load requires the target run to use the same `autoep_size` as the save run. To change `autoep_size` for the same AutoEP-detected model topology, convert the saved checkpoint to Universal Checkpoint format:
+This is the same save call used for AutoTP and AutoEP training runs. AutoTP
+checkpoints include Universal Checkpoint metadata that describes tensor-parallel
+parameter layouts. AutoEP checkpoints also use the normal save API; AutoEP's
+expert-specific layout is described in the AutoEP requirements section below.
+
+### Step 2: Convert ZeRO Checkpoint to Universal Format
+
+Once you have a ZeRO checkpoint, convert it to Universal format with the
+`ds_to_universal.py` script provided by DeepSpeed:
 
 ```bash
 python deepspeed/checkpoint/ds_to_universal.py \
@@ -121,41 +49,112 @@ python deepspeed/checkpoint/ds_to_universal.py \
   --output_folder /path/to/universal_checkpoint
 ```
 
-During conversion, `ds_to_universal.py` reads `ds_autoep_layers` (or the legacy `autoep_layers` key), consolidates each AutoEP layer's routed expert files, and writes the full expert tensors to paths such as `zero/<expert_key_prefix>.w1/fp32.pt`. These files are tagged with `is_expert_param` and `ep_num_experts`, which are the load-time signals used for AutoEP expert resharding. When matching expert optimizer shards are available, the converter also writes optimizer state files such as `exp_avg.pt` and `exp_avg_sq.pt` next to the converted parameter.
+This script processes the saved ZeRO checkpoint and writes a Universal
+checkpoint to the output folder. Pass the `--help` flag to see additional
+options.
 
-Load the converted checkpoint through the Universal Checkpoint path:
+For AutoTP checkpoints, the converter uses the saved Universal Checkpoint
+metadata (`UNIVERSAL_CHECKPOINT_INFO`) to reconstruct tensor-parallel parameters
+correctly, including row-parallel, column-parallel, replicated, fused, and
+sub-parameter layouts.
+
+### AutoEP Requirements and Limitations
+
+AutoEP checkpoints are saved as regular DeepSpeed checkpoints, but routed expert
+weights have an additional layout. With AutoEP enabled, DeepSpeed writes the
+routed expert weights (`w1`, `w2`, and `w3`) into per-expert files named like
+`layer_<moe_layer_id>_expert_<global_expert_id>_mp_rank_<NN>_model_states.pt`.
+The regular model checkpoint records AutoEP metadata in `ds_autoep_layers`; older
+checkpoints may use the legacy `autoep_layers` key. Router, gate, shared-expert,
+and other non-routed-expert parameters stay in the regular
+`mp_rank_*_model_states.pt` files and use the standard Universal Checkpointing
+path.
+
+Use ZeRO Stage 1 or ZeRO Stage 2 for the current AutoEP Universal Checkpoint
+conversion path. ZeRO Stage 3 AutoEP Universal Checkpoint conversion is not
+supported; when AutoEP metadata is present, the converter raises
+`NotImplementedError` with the message that AutoEP currently requires ZeRO Stage
+1 or 2.
+
+During conversion, `ds_to_universal.py` reads `ds_autoep_layers` or the legacy
+`autoep_layers` key, consolidates each AutoEP layer's routed expert files, and
+writes full expert tensors to paths such as `zero/<expert_key_prefix>.w1/fp32.pt`.
+These files are tagged with `is_expert_param` and `ep_num_experts`, which are the
+load-time signals used for AutoEP expert resharding. When matching expert
+optimizer shards are available, the converter also writes optimizer state files
+such as `exp_avg.pt` and `exp_avg_sq.pt` next to the converted parameter.
+
+Regular AutoEP checkpoint load requires the target run to use the same
+`autoep_size` as the save run. To change `autoep_size` for the same
+AutoEP-detected model topology, convert the saved checkpoint to Universal format
+and load the Universal checkpoint.
+
+In the Universal Checkpoint load path, AutoEP routed experts are restored from
+the `zero/` parameter layout rather than from the regular
+`layer_*_expert_*_model_states.pt` files. The target run's AutoEP process group
+supplies the load-side expert-parallel rank and size. For each tagged expert
+tensor, the loader slices the saved expert dimension by `ep_rank` and `ep_size`
+when `ep_size > 1`.
+
+The target model still needs to expose matching AutoEP parameter names and
+compatible shapes, for example `<module_path>.experts.w1`,
+`<module_path>.experts.w2`, and `<module_path>.experts.w3`. Universal
+Checkpointing changes the expert-parallel sharding for matching tensors; it does
+not translate between different model families, different module paths, or
+arbitrary expert parameter names. The target AutoEP configuration must also be
+valid before checkpoint loading: `autoep_size` must divide the target pipeline
+stage size (`world_size / pp_size`) and every detected target layer's expert
+count.
+
+Topology changes are limited to `autoep_size` resharding for matching
+AutoEP-managed expert parameters. For every AutoEP layer in the checkpoint, the
+saved `ep_num_experts` must be divisible by the target `autoep_size` when the
+target `ep_size > 1`. For example, an 8-expert checkpoint can load with target
+`autoep_size` values of 1, 2, 4, or 8, but not 3. With `autoep_size=1`, the expert
+tensor is not sliced, but the target parameter must still have the compatible
+full expert shape.
+
+Additional AutoEP failure cases:
+
+- For ZeRO Stage 1 and ZeRO Stage 2 conversion, expert checkpoint files without
+  `ds_autoep_layers` or `autoep_layers` metadata raise a `RuntimeError`.
+- Existing DeepSpeed MoE or Megatron-DeepSpeed expert checkpoint files may share
+  the `layer_<moe_layer_id>_expert_<global_expert_id>_mp_rank_<NN>_model_states.pt`
+  naming convention, but they use native `deepspeed_moe` expert parameter names
+  and do not carry AutoEP metadata. Loading or converting those checkpoints into
+  AutoEP requires a separate model-specific migration step.
+- If AutoEP metadata is present but an expected per-expert model file is missing,
+  conversion raises `FileNotFoundError`.
+- More than one `mp_rank_*` expert file for the same `(layer, expert)` pair
+  raises `NotImplementedError`; combined AutoEP + AutoTP topology changes are
+  not documented by this path.
+- AutoEP optimizer-state consolidation is best effort. It succeeds for the usual
+  ZeRO Stage 1 or ZeRO Stage 2 AutoEP training checkpoints that include matching
+  expert optimizer shards. If `expp_rank_*_mp_rank_*_optim_states.pt` files or
+  matching state entries are absent, the converter still writes the model
+  parameter `fp32.pt` files and skips unavailable optimizer state files.
+
+### Step 3: Resume Training with Universal Checkpoint
+
+With the Universal checkpoint ready, resume training by enabling Universal
+Checkpoint loading in your DeepSpeed config:
 
 ```json
 {
   "checkpoint": {
     "load_universal": true
-  },
-  "expert_parallel": {
-    "enabled": true,
-    "autoep_size": 2,
-    "preset_model": "mixtral"
   }
 }
 ```
+
+Then load the converted checkpoint through the normal DeepSpeed checkpoint API:
 
 ```python
 engine.load_checkpoint("/path/to/universal_checkpoint", tag=tag)
 ```
 
-In the Universal Checkpoint load path, AutoEP routed experts are restored from the `zero/` parameter layout rather than from the regular `layer_*_expert_*_model_states.pt` files. The target run's AutoEP process group supplies the load-side expert-parallel rank and size. For each tagged expert tensor, the loader slices the saved expert dimension by `ep_rank` and `ep_size` when `ep_size > 1`.
-
-The target model still needs to expose matching AutoEP parameter names and compatible shapes, for example `<module_path>.experts.w1`, `<module_path>.experts.w2`, and `<module_path>.experts.w3`. Universal Checkpointing changes the expert-parallel sharding for matching tensors; it does not translate between different model families, different module paths, or arbitrary expert parameter names. The target AutoEP configuration must also be valid before checkpoint loading, including `autoep_size` divisibility by the target stage size and by every detected target layer's expert count.
-
-Topology changes are limited to `autoep_size` resharding for matching AutoEP-managed expert parameters. For every AutoEP layer in the checkpoint, the saved `ep_num_experts` must be divisible by the target `autoep_size` when the target `ep_size > 1`. For example, an 8-expert checkpoint can load with target `autoep_size` values of 1, 2, 4, or 8, but not 3. With `autoep_size=1`, the expert tensor is not sliced, but the target parameter must still have the compatible full expert shape.
-
-Current limits and failure cases:
-
-- ZeRO Stage 3 AutoEP Universal Checkpoint conversion is not supported. When AutoEP metadata is present, the converter raises `NotImplementedError` with the message that "AutoEP currently requires ZeRO Stage 1 or 2."
-- For ZeRO Stage 1 and ZeRO Stage 2 conversion, expert checkpoint files without `ds_autoep_layers` / `autoep_layers` metadata raise a `RuntimeError`.
-- Existing DeepSpeed MoE or Megatron-DeepSpeed expert checkpoint files may share the `layer_<moe_layer_id>_expert_<global_expert_id>_mp_rank_<NN>_model_states.pt` naming convention, but they use native `deepspeed_moe` expert parameter names and do not carry AutoEP metadata. Loading or converting those checkpoints into AutoEP requires a separate model-specific migration step.
-- If AutoEP metadata is present but an expected per-expert model file is missing, conversion raises `FileNotFoundError`.
-- More than one `mp_rank_*` expert file for the same `(layer, expert)` pair raises `NotImplementedError`; combined AutoEP + AutoTP topology changes are not documented by this path.
-- AutoEP optimizer-state consolidation is best effort. It succeeds for the usual ZeRO Stage 1 / 2 AutoEP training checkpoints that include matching expert optimizer shards. If `expp_rank_*_mp_rank_*_optim_states.pt` files or matching state entries are absent, the converter still writes the model parameter `fp32.pt` files and skips unavailable optimizer state files.
+The target run still needs the DeepSpeed parallelism configuration that matches
+the model and topology you want to use for resumed training.
 
 
 ## Conclusion

--- a/docs/code-docs/source/moe.rst
+++ b/docs/code-docs/source/moe.rst
@@ -1,15 +1,15 @@
 Mixture of Experts (MoE)
 ========================
 
-Layer specification
---------------------
-.. autoclass:: deepspeed.moe.layer.MoE
-    :members:
+DeepSpeed provides two MoE implementations: AutoEP (Automatic Expert
+Parallelism), which automatically detects and replaces supported Hugging Face MoE
+layers, and DeepSpeed MoE, the explicit ``deepspeed.moe.layer.MoE`` API for
+constructing MoE layers in model code.
 
 AutoEP (Automatic Expert Parallelism)
 ---------------------------------------
 
-AutoEP automatically detects MoE layers in HuggingFace models and replaces them
+AutoEP automatically detects MoE layers in Hugging Face models and replaces them
 with EP-enabled versions, requiring zero model code changes. It follows the
 pattern of AutoTP (Automatic Tensor Parallelism).
 
@@ -18,7 +18,7 @@ pattern of AutoTP (Automatic Tensor Parallelism).
 ``deepseek_v3`` (DeepSeek-V3), and ``llama4`` (LLaMA-4).
 
 The preset name means AutoEP knows the router, expert, and weight naming
-patterns for that model family. Running a HuggingFace model also requires a
+patterns for that model family. Running a Hugging Face model also requires a
 Transformers build that exposes the matching config/model classes,
 ``model.config.model_type`` value, and fused expert layout.
 
@@ -94,3 +94,14 @@ Transformers build that exposes the matching config/model classes,
 - DeepSeek-V2 and DeepSeek-V3 AutoEP do not support load-balance expert bias
   yet. The built-in DeepSeek presets disable it by default; explicit non-null
   values fail.
+
+DeepSpeed MoE
+-------------
+
+DeepSpeed MoE exposes the explicit ``deepspeed.moe.layer.MoE`` layer API for
+models that construct MoE layers directly. See the `Mixture of Experts
+(DeepSpeed MoE) tutorial </tutorials/mixture-of-experts/>`__ for training
+examples and configuration details.
+
+.. autoclass:: deepspeed.moe.layer.MoE
+    :members:

--- a/docs/code-docs/source/moe.rst
+++ b/docs/code-docs/source/moe.rst
@@ -47,3 +47,8 @@ pattern of AutoTP (Automatic Tensor Parallelism).
   for functional testing on a single GPU.
 - AutoTP and sequence parallelism cannot both be active simultaneously.
 - Checkpoint save/load requires matching ``autoep_size``.
+  To change ``autoep_size`` across runs for the same AutoEP-detected model
+  topology, convert the checkpoint to Universal Checkpoint format and load it
+  with ``checkpoint.load_universal``; see the
+  `Universal Checkpointing tutorial </tutorials/universal-checkpointing/>`__
+  for the detailed flow and constraints.


### PR DESCRIPTION
This PR is a reviewable patch branch for AutoEP PR #7938, targeting the private staging branch `codex/autoep-pr7938-staging` in `tohtana/DeepSpeed` only.

It is intentionally not opened against `deepspeedai/DeepSpeed`.

Source tracking:
- dev_ds TODO: tohtana/dev_ds#89 / PR https://github.com/tohtana/dev_ds/pull/95
- Upstream baseline: deepspeedai/DeepSpeed#7938 head `5af8e41da0f5cf4656a1d5641a9268e81277dd57`
- Local patch source: `/mnt/user_storage/dev_ds_worktrees/autoep-pr7938-review/document-autoep-universal-checkpointing/DeepSpeed`

Validation already captured in the corresponding dev_ds artifacts. This PR is for GitHub review and controlled staging-branch merge.
