### PR TITLE
AutoEP: fix DeepSeek forward parity without expert bias

### DIFF
--- a/deepspeed/module_inject/auto_ep.py
+++ b/deepspeed/module_inject/auto_ep.py
@@ -24,6 +24,7 @@ from deepspeed.module_inject.auto_ep_config import (
     PRESET_MODELS,
     _UNSET,
 )
+from deepspeed.module_inject.auto_ep_preset_adapters import ForwardContract, get_preset_adapter
 
 
 def _remove_transformers_output_capture_hooks(model: nn.Module) -> int:
@@ -152,11 +153,11 @@ def _infer_hidden_and_ffn_size(
 def _detect_forward_contract(
     moe_module: nn.Module,
     router_module: nn.Module,
-) -> tuple[bool, Literal["moe_block", "router", "none"], int | None, str | None]:
+) -> ForwardContract:
     """Detect the forward contract for router logits capture.
 
     Returns:
-        (return_router_logits, capture_target, capture_index, capture_layer_name)
+        ForwardContract with router-logit return and capture metadata.
     """
     # Check for OutputRecorder on the model (transformers 5.0.0 pattern)
     # Look for _can_record_outputs attribute on parent modules
@@ -195,7 +196,12 @@ def _detect_forward_contract(
                     elif isinstance(val, int):
                         capture_index = val
 
-    return return_router_logits, capture_target, capture_index, capture_layer_name
+    return ForwardContract(
+        return_router_logits=return_router_logits,
+        capture_target=capture_target,
+        capture_index=capture_index,
+        capture_layer_name=capture_layer_name,
+    )
 
 
 class AutoEP:
@@ -215,6 +221,7 @@ class AutoEP:
         presets_to_try = self._resolve_presets()
 
         for preset_name, preset in presets_to_try:
+            adapter = get_preset_adapter(preset.preset_adapter)
             pattern = re.compile(preset.moe_layer_pattern)
 
             for module_name, module in self.model.named_modules():
@@ -321,20 +328,10 @@ class AutoEP:
                 else:
                     score_apply = preset.score_apply
 
-                # Resolve route_norm
-                if self.config.route_norm is not None:
-                    route_norm = self.config.route_norm
-                elif preset_name == "deepseek_v2":
-                    route_norm = preset.route_norm
-                else:
-                    cfg_norm = getattr(self.model_config, 'norm_topk_prob', None)
-                    if cfg_norm is not None:
-                        route_norm = bool(cfg_norm)
-                    else:
-                        route_norm = preset.route_norm
+                route_norm = adapter.resolve_route_norm(self.config, preset, self.model_config)
 
-                # Resolve routed scaling. DeepSeek configs expose this as
-                # routed_scaling_factor; other presets keep the AutoEP scale.
+                # Resolve routed scaling from model config when available; otherwise
+                # keep the AutoEP scale.
                 route_scale = self.config.route_scale
                 if self.config.routed_scaling_factor != "auto":
                     route_scale = float(self.config.routed_scaling_factor)
@@ -343,43 +340,14 @@ class AutoEP:
                     if cfg_route_scale is not None:
                         route_scale = float(cfg_route_scale)
 
-                num_expert_groups = self.config.num_expert_groups
-                num_limited_groups = self.config.num_limited_groups
-                group_score_func = "top2_sum"
-                if preset_name == "deepseek_v2":
-                    topk_method = getattr(self.model_config, 'topk_method', None)
-                    if topk_method == "group_limited_greedy":
-                        num_expert_groups = num_expert_groups or getattr(self.model_config, 'n_group', None)
-                        num_limited_groups = num_limited_groups or getattr(self.model_config, 'topk_group', None)
-                        group_score_func = "max"
-                elif preset_name == "deepseek_v3":
-                    num_expert_groups = num_expert_groups or getattr(self.model_config, 'n_group', None)
-                    num_limited_groups = num_limited_groups or getattr(self.model_config, 'topk_group', None)
+                group_routing = adapter.resolve_group_routing(self.config, self.model_config)
 
                 # Check gate bias
                 gate_bias = preset.gate_bias
                 if router_weight is not None:
                     gate_bias = getattr(router_child, 'bias', None) is not None
 
-                # Detect forward contract
-                return_router_logits, capture_target, capture_index, capture_layer_name = \
-                    _detect_forward_contract(module, router_child)
-                if preset_name == "qwen3_5_moe":
-                    # Qwen3.5 HF captures softmaxed router output through an
-                    # OutputRecorder on Qwen3_5MoeTopKRouter. AutoEP replaces
-                    # the owning MoE block, so the replacement returns that
-                    # value at output index 1 for recorder retargeting during
-                    # layer replacement.
-                    return_router_logits = True
-                    capture_target = "router"
-                    capture_index = 1
-                if preset_name == "llama4":
-                    # HF Llama4TextMoe always returns (hidden_states, router_logits);
-                    # the decoder layer unpacks that tuple even when CausalLM loss
-                    # ignores router logits.
-                    return_router_logits = True
-                    if capture_target == "none":
-                        capture_target = "router"
+                forward_contract = adapter.adjust_forward_contract(_detect_forward_contract(module, router_child))
 
                 # Check shared experts
                 has_shared = False
@@ -423,19 +391,22 @@ class AutoEP:
                     score_apply=score_apply,
                     route_norm=route_norm,
                     gate_bias=gate_bias,
-                    return_router_logits=return_router_logits,
-                    router_logits_capture_target=capture_target,
-                    router_logits_capture_index=capture_index,
-                    router_logits_capture_layer_name=capture_layer_name,
+                    return_router_logits=forward_contract.return_router_logits,
+                    router_logits_capture_target=forward_contract.capture_target,
+                    router_logits_capture_index=forward_contract.capture_index,
+                    router_logits_capture_layer_name=forward_contract.capture_layer_name,
                     has_shared_experts=has_shared,
                     shared_experts_name=shared_name,
                     shared_experts_gate_name=shared_gate_name,
                     route_scale=route_scale,
-                    num_expert_groups=num_expert_groups,
-                    num_limited_groups=num_limited_groups,
-                    group_score_func=group_score_func,
+                    num_expert_groups=group_routing.num_expert_groups,
+                    num_limited_groups=group_routing.num_limited_groups,
+                    group_score_func=group_routing.group_score_func,
                     supports_expert_bias=preset.supports_expert_bias,
                     unsupported_router_bias_names=preset.unsupported_router_bias_names,
+                    preset_adapter=preset.preset_adapter,
+                    router_logits_capture_mode=forward_contract.router_logits_capture_mode,
+                    moe_output_shape=forward_contract.moe_output_shape,
                 )
                 specs.append(spec)
                 logger.debug(f"Detected MoE layer: {module_name} (family={preset_name}, "
@@ -474,63 +445,18 @@ class AutoEP:
 
         # Replace in-place on parent
         setattr(parent, child_name, replacement)
-        self._retarget_transformers_output_recorders(spec, replacement)
+        adapter = get_preset_adapter(spec.preset_adapter)
+        adapter.retarget_transformers_output_recorders(
+            self.model,
+            spec,
+            replacement,
+            self._retargeted_transformers_output_recorders,
+            _remove_transformers_output_capture_hooks,
+        )
 
         logger.info(f"AutoEP: replaced '{spec.moe_module_name}' with AutoEPMoELayer "
                     f"(ep_size={ep_size}, ep_rank={ep_rank}, "
                     f"local_experts={replacement.num_local_experts})")
-
-    def _retarget_transformers_output_recorders(self, spec: MoELayerSpec, replacement: nn.Module) -> None:
-        """Retarget HF output capture after AutoEP replaces a recorded MoE module."""
-        if spec.model_family != "qwen3_5_moe":
-            return
-
-        recorder_key = f"{spec.model_family}:{replacement.__class__.__module__}.{replacement.__class__.__qualname__}"
-        if recorder_key in self._retargeted_transformers_output_recorders:
-            return
-        self._retargeted_transformers_output_recorders.add(recorder_key)
-
-        try:
-            from transformers.utils.output_capturing import _CAN_RECORD_REGISTRY, OutputRecorder
-        except Exception as exc:
-            logger.warning(f"AutoEP: could not retarget Qwen3.5 router-logit output capture: {exc}")
-            return
-
-        retargeted = 0
-        replacement_cls = replacement.__class__
-        for module in self.model.modules():
-            module_config = getattr(module, "config", None)
-            model_type = getattr(module_config, "model_type", None)
-            class_name = module.__class__.__name__
-            if model_type != "qwen3_5_moe_text" and "Qwen3_5Moe" not in class_name:
-                continue
-
-            registry_key = str(module.__class__)
-            record_outputs = getattr(module, "_can_record_outputs", None)
-            registry_outputs = _CAN_RECORD_REGISTRY.get(registry_key)
-            base_outputs = record_outputs if isinstance(record_outputs, dict) else registry_outputs
-            if not isinstance(base_outputs, dict) or "router_logits" not in base_outputs:
-                continue
-
-            retargeted_outputs = dict(base_outputs)
-            retargeted_outputs["router_logits"] = OutputRecorder(replacement_cls, index=1)
-            module._can_record_outputs = retargeted_outputs
-            _CAN_RECORD_REGISTRY[registry_key] = retargeted_outputs
-
-            if getattr(module, "_output_capturing_hooks_installed", False):
-                removed = _remove_transformers_output_capture_hooks(module)
-                if removed:
-                    logger.debug(f"AutoEP: removed {removed} stale HF output-capturing hook(s) "
-                                 f"from {class_name}.")
-            module._output_capturing_hooks_installed = False
-            retargeted += 1
-
-        if retargeted:
-            logger.info("AutoEP: retargeted Qwen3.5 HF router-logit output capture to record "
-                        f"{replacement_cls.__name__} output index 1 on {retargeted} module(s).")
-        else:
-            logger.warning("AutoEP: Qwen3.5 AutoEP conversion did not find a HF output-capture registry "
-                           "entry for router_logits.")
 
     def _apply_config_overrides(self, preset: MoEModelPreset) -> MoEModelPreset:
         """Apply user config field overrides to a resolved preset.

--- a/deepspeed/module_inject/auto_ep.py
+++ b/deepspeed/module_inject/auto_ep.py
@@ -324,12 +324,37 @@ class AutoEP:
                 # Resolve route_norm
                 if self.config.route_norm is not None:
                     route_norm = self.config.route_norm
+                elif preset_name == "deepseek_v2":
+                    route_norm = preset.route_norm
                 else:
                     cfg_norm = getattr(self.model_config, 'norm_topk_prob', None)
                     if cfg_norm is not None:
                         route_norm = bool(cfg_norm)
                     else:
                         route_norm = preset.route_norm
+
+                # Resolve routed scaling. DeepSeek configs expose this as
+                # routed_scaling_factor; other presets keep the AutoEP scale.
+                route_scale = self.config.route_scale
+                if self.config.routed_scaling_factor != "auto":
+                    route_scale = float(self.config.routed_scaling_factor)
+                else:
+                    cfg_route_scale = getattr(self.model_config, 'routed_scaling_factor', None)
+                    if cfg_route_scale is not None:
+                        route_scale = float(cfg_route_scale)
+
+                num_expert_groups = self.config.num_expert_groups
+                num_limited_groups = self.config.num_limited_groups
+                group_score_func = "top2_sum"
+                if preset_name == "deepseek_v2":
+                    topk_method = getattr(self.model_config, 'topk_method', None)
+                    if topk_method == "group_limited_greedy":
+                        num_expert_groups = num_expert_groups or getattr(self.model_config, 'n_group', None)
+                        num_limited_groups = num_limited_groups or getattr(self.model_config, 'topk_group', None)
+                        group_score_func = "max"
+                elif preset_name == "deepseek_v3":
+                    num_expert_groups = num_expert_groups or getattr(self.model_config, 'n_group', None)
+                    num_limited_groups = num_limited_groups or getattr(self.model_config, 'topk_group', None)
 
                 # Check gate bias
                 gate_bias = preset.gate_bias
@@ -405,6 +430,10 @@ class AutoEP:
                     has_shared_experts=has_shared,
                     shared_experts_name=shared_name,
                     shared_experts_gate_name=shared_gate_name,
+                    route_scale=route_scale,
+                    num_expert_groups=num_expert_groups,
+                    num_limited_groups=num_limited_groups,
+                    group_score_func=group_score_func,
                 )
                 specs.append(spec)
                 logger.debug(f"Detected MoE layer: {module_name} (family={preset_name}, "

--- a/deepspeed/module_inject/auto_ep.py
+++ b/deepspeed/module_inject/auto_ep.py
@@ -434,6 +434,8 @@ class AutoEP:
                     num_expert_groups=num_expert_groups,
                     num_limited_groups=num_limited_groups,
                     group_score_func=group_score_func,
+                    supports_expert_bias=preset.supports_expert_bias,
+                    unsupported_router_bias_names=preset.unsupported_router_bias_names,
                 )
                 specs.append(spec)
                 logger.debug(f"Detected MoE layer: {module_name} (family={preset_name}, "

--- a/deepspeed/module_inject/auto_ep_config.py
+++ b/deepspeed/module_inject/auto_ep_config.py
@@ -43,6 +43,8 @@ class MoEModelPreset:
     shared_experts_pattern: str = ""
     shared_experts_gate_pattern: str = ""
     autoep_config_defaults: dict[str, Any] = field(default_factory=dict)
+    supports_expert_bias: bool = True
+    unsupported_router_bias_names: tuple[str, ...] = ()
 
 
 @dataclass
@@ -76,6 +78,8 @@ class MoELayerSpec:
     num_expert_groups: int | None = None
     num_limited_groups: int | None = None
     group_score_func: Literal["max", "top2_sum"] = "top2_sum"
+    supports_expert_bias: bool = True
+    unsupported_router_bias_names: tuple[str, ...] = ()
 
 
 @dataclass
@@ -214,6 +218,7 @@ PRESET_MODELS: dict[str, MoEModelPreset] = {
         has_shared_experts=True,
         shared_experts_pattern="shared_experts",
         autoep_config_defaults={"load_balance_coeff": None},
+        supports_expert_bias=False,
     ),
     "deepseek_v3":
     MoEModelPreset(
@@ -233,6 +238,8 @@ PRESET_MODELS: dict[str, MoEModelPreset] = {
         has_shared_experts=True,
         shared_experts_pattern="shared_experts",
         autoep_config_defaults={"load_balance_coeff": None},
+        supports_expert_bias=False,
+        unsupported_router_bias_names=("e_score_correction_bias", ),
     ),
     "llama4":
     MoEModelPreset(

--- a/deepspeed/module_inject/auto_ep_config.py
+++ b/deepspeed/module_inject/auto_ep_config.py
@@ -72,6 +72,10 @@ class MoELayerSpec:
     has_shared_experts: bool
     shared_experts_name: str
     shared_experts_gate_name: str = ""
+    route_scale: float = 1.0
+    num_expert_groups: int | None = None
+    num_limited_groups: int | None = None
+    group_score_func: Literal["max", "top2_sum"] = "top2_sum"
 
 
 @dataclass
@@ -205,10 +209,11 @@ PRESET_MODELS: dict[str, MoEModelPreset] = {
         top_k_attr="num_experts_per_tok",
         score_func="softmax",
         score_apply="post",
-        route_norm=True,
+        route_norm=False,
         gate_bias=False,
         has_shared_experts=True,
         shared_experts_pattern="shared_experts",
+        autoep_config_defaults={"load_balance_coeff": None},
     ),
     "deepseek_v3":
     MoEModelPreset(
@@ -227,6 +232,7 @@ PRESET_MODELS: dict[str, MoEModelPreset] = {
         gate_bias=False,
         has_shared_experts=True,
         shared_experts_pattern="shared_experts",
+        autoep_config_defaults={"load_balance_coeff": None},
     ),
     "llama4":
     MoEModelPreset(
@@ -433,6 +439,9 @@ def validate_autoep_config(
     if isinstance(config.top_k, int) and config.top_k_attr is not None:
         logger.warning("top_k is explicitly set; top_k_attr will be ignored.")
 
+    if config.routed_scaling_factor != "auto" and not isinstance(config.routed_scaling_factor, (int, float)):
+        raise ValueError("routed_scaling_factor must be a number or 'auto'")
+
     # Validate shared expert field pairing
     if config.has_shared_experts is True and not config.shared_experts_pattern:
         logger.warning("has_shared_experts=True but shared_experts_pattern is not set. "
@@ -503,11 +512,21 @@ def validate_autoep_post_detection(
                              f"autoep_size={config.autoep_size}. "
                              f"Suggested autoep_size values: {valid_sizes}")
 
+        num_expert_groups = spec.num_expert_groups if spec.num_expert_groups is not None else config.num_expert_groups
+        num_limited_groups = spec.num_limited_groups if spec.num_limited_groups is not None else config.num_limited_groups
+
         # Validate num_expert_groups divides num_experts
-        if config.num_expert_groups is not None:
-            if spec.num_experts % config.num_expert_groups != 0:
-                raise ValueError(f"num_expert_groups ({config.num_expert_groups}) must divide "
+        if num_expert_groups is not None:
+            if spec.num_experts % num_expert_groups != 0:
+                raise ValueError(f"num_expert_groups ({num_expert_groups}) must divide "
                                  f"num_experts ({spec.num_experts}) in layer "
+                                 f"'{spec.moe_module_name}'")
+            if num_limited_groups is None:
+                raise ValueError(f"num_limited_groups must be set when num_expert_groups is set "
+                                 f"in layer '{spec.moe_module_name}'")
+            if num_limited_groups > num_expert_groups:
+                raise ValueError(f"num_limited_groups ({num_limited_groups}) must be <= "
+                                 f"num_expert_groups ({num_expert_groups}) in layer "
                                  f"'{spec.moe_module_name}'")
 
 

--- a/deepspeed/module_inject/auto_ep_config.py
+++ b/deepspeed/module_inject/auto_ep_config.py
@@ -45,6 +45,7 @@ class MoEModelPreset:
     autoep_config_defaults: dict[str, Any] = field(default_factory=dict)
     supports_expert_bias: bool = True
     unsupported_router_bias_names: tuple[str, ...] = ()
+    preset_adapter: str = "default"
 
 
 @dataclass
@@ -80,6 +81,9 @@ class MoELayerSpec:
     group_score_func: Literal["max", "top2_sum"] = "top2_sum"
     supports_expert_bias: bool = True
     unsupported_router_bias_names: tuple[str, ...] = ()
+    preset_adapter: str = "default"
+    router_logits_capture_mode: Literal["raw", "post_score"] = "post_score"
+    moe_output_shape: Literal["batched", "flat"] = "batched"
 
 
 @dataclass
@@ -199,6 +203,7 @@ PRESET_MODELS: dict[str, MoEModelPreset] = {
         has_shared_experts=True,
         shared_experts_pattern="shared_expert",
         shared_experts_gate_pattern="shared_expert_gate",
+        preset_adapter="qwen3_5_moe",
     ),
     "deepseek_v2":
     MoEModelPreset(
@@ -219,6 +224,7 @@ PRESET_MODELS: dict[str, MoEModelPreset] = {
         shared_experts_pattern="shared_experts",
         autoep_config_defaults={"load_balance_coeff": None},
         supports_expert_bias=False,
+        preset_adapter="deepseek_v2",
     ),
     "deepseek_v3":
     MoEModelPreset(
@@ -240,6 +246,7 @@ PRESET_MODELS: dict[str, MoEModelPreset] = {
         autoep_config_defaults={"load_balance_coeff": None},
         supports_expert_bias=False,
         unsupported_router_bias_names=("e_score_correction_bias", ),
+        preset_adapter="deepseek_v3",
     ),
     "llama4":
     MoEModelPreset(
@@ -259,6 +266,7 @@ PRESET_MODELS: dict[str, MoEModelPreset] = {
         has_shared_experts=True,
         shared_experts_pattern="shared_expert",
         autoep_config_defaults={"load_balance_coeff": None},
+        preset_adapter="llama4",
     ),
 }
 

--- a/deepspeed/module_inject/auto_ep_layer.py
+++ b/deepspeed/module_inject/auto_ep_layer.py
@@ -27,8 +27,6 @@ from deepspeed.moe.ep_experts import GroupedExperts
 from deepspeed.moe.ep_kernels import TokenReorderer
 from deepspeed.moe.ep_repack import repack_expert_weights
 
-_DEEPSEEK_PRESETS = {"deepseek_v2", "deepseek_v3"}
-
 # ---------------------------------------------------------------------------
 # Named tuples
 # ---------------------------------------------------------------------------
@@ -367,13 +365,17 @@ class AutoEPMoELayer(nn.Module):
 
         # Router: copy gate weights from source
         source_gate = getattr(source_module, spec.router_name)
-        if spec.model_family in _DEEPSEEK_PRESETS:
-            if resolved_config.load_balance_coeff is not None:
-                raise ValueError("AutoEP DeepSeek presets do not support load_balance_coeff/expert_bias yet. "
-                                 "Set load_balance_coeff=None.")
-            score_correction_bias = getattr(source_gate, "e_score_correction_bias", None)
-            if score_correction_bias is not None and torch.count_nonzero(score_correction_bias.detach()).item() != 0:
-                raise ValueError("AutoEP DeepSeek presets do not support nonzero e_score_correction_bias yet.")
+        if not spec.supports_expert_bias and resolved_config.load_balance_coeff is not None:
+            raise ValueError(f"AutoEP preset '{spec.model_family}' does not support load_balance_coeff/expert_bias "
+                             "yet. Set load_balance_coeff=None.")
+        for bias_name in spec.unsupported_router_bias_names:
+            router_bias = getattr(source_gate, bias_name, None)
+            if router_bias is None:
+                continue
+            if torch.is_tensor(router_bias) and torch.count_nonzero(router_bias.detach()).item() == 0:
+                continue
+            raise ValueError(f"AutoEP preset '{spec.model_family}' does not support nonzero router bias "
+                             f"'{bias_name}' yet.")
         self.router = TokenChoiceTopKRouter(
             dim=spec.hidden_size,
             num_experts=spec.num_experts,

--- a/deepspeed/module_inject/auto_ep_layer.py
+++ b/deepspeed/module_inject/auto_ep_layer.py
@@ -27,6 +27,8 @@ from deepspeed.moe.ep_experts import GroupedExperts
 from deepspeed.moe.ep_kernels import TokenReorderer
 from deepspeed.moe.ep_repack import repack_expert_weights
 
+_DEEPSEEK_PRESETS = {"deepseek_v2", "deepseek_v3"}
+
 # ---------------------------------------------------------------------------
 # Named tuples
 # ---------------------------------------------------------------------------
@@ -361,19 +363,28 @@ class AutoEPMoELayer(nn.Module):
         self.hidden_size = spec.hidden_size
         self.ep_group_name = f"ep_size_{ep_size}"
         self.ep_group = None  # Set by set_deepspeed_parallelism()
+        resolved_config = resolve_autoep_config_defaults(config, spec.model_family)
 
         # Router: copy gate weights from source
         source_gate = getattr(source_module, spec.router_name)
+        if spec.model_family in _DEEPSEEK_PRESETS:
+            if resolved_config.load_balance_coeff is not None:
+                raise ValueError("AutoEP DeepSeek presets do not support load_balance_coeff/expert_bias yet. "
+                                 "Set load_balance_coeff=None.")
+            score_correction_bias = getattr(source_gate, "e_score_correction_bias", None)
+            if score_correction_bias is not None and torch.count_nonzero(score_correction_bias.detach()).item() != 0:
+                raise ValueError("AutoEP DeepSeek presets do not support nonzero e_score_correction_bias yet.")
         self.router = TokenChoiceTopKRouter(
             dim=spec.hidden_size,
             num_experts=spec.num_experts,
-            num_expert_groups=config.num_expert_groups,
-            num_limited_groups=config.num_limited_groups,
+            num_expert_groups=spec.num_expert_groups,
+            num_limited_groups=spec.num_limited_groups,
             top_k=spec.top_k,
             score_func=spec.score_func,
             route_norm=route_norm,
-            route_scale=config.route_scale,
+            route_scale=spec.route_scale,
             gate_bias=spec.gate_bias,
+            group_score_func=spec.group_score_func,
         )
         # Copy gate weights
         self.router.gate.weight.data.copy_(source_gate.weight.data)
@@ -428,7 +439,6 @@ class AutoEPMoELayer(nn.Module):
                 param.allreduce = True
 
         # Load balancing buffers
-        resolved_config = resolve_autoep_config_defaults(config, spec.model_family)
         self.load_balance_coeff = resolved_config.load_balance_coeff
         buf_device = source_gate.weight.device
         if self.load_balance_coeff is not None:

--- a/deepspeed/module_inject/auto_ep_layer.py
+++ b/deepspeed/module_inject/auto_ep_layer.py
@@ -350,6 +350,8 @@ class AutoEPMoELayer(nn.Module):
         self.return_router_logits = spec.return_router_logits
         self.router_logits_capture_target = spec.router_logits_capture_target
         self.router_logits_capture_index = spec.router_logits_capture_index
+        self.router_logits_capture_mode = spec.router_logits_capture_mode
+        self.moe_output_shape = spec.moe_output_shape
         self.top_k = spec.top_k
         self.score_apply = resolve_score_apply_mode(spec, config.score_apply)
         self.combine_impl = resolve_combine_impl(config.combine_impl)
@@ -469,9 +471,7 @@ class AutoEPMoELayer(nn.Module):
         def hook_fn(module, input, output):
             x = input[0]  # [T, H]
             logits = module.gate(x)  # [T, E_global]
-            # Llama4TextMoe captures raw gate logits. Other currently supported
-            # router-capture contracts expect post-score values.
-            if self.model_family != "llama4":
+            if self.router_logits_capture_mode == "post_score":
                 if self.router.score_func == "softmax":
                     logits = torch.softmax(logits.float(), dim=-1).to(logits.dtype)
                 elif self.router.score_func == "sigmoid":
@@ -515,7 +515,7 @@ class AutoEPMoELayer(nn.Module):
 
         Returns:
             [B, S, H] or ([B, S, H], [T, E]) if return_router_logits.
-            Llama4 returns ([T, H], [T, E]) to match HF Llama4TextMoe.
+            Some HF MoE contracts return ([T, H], [T, E]) instead.
         """
         bsz, seqlen, hdim = hidden_states.shape
         x = hidden_states.reshape(-1, hdim)  # [T, H]
@@ -576,7 +576,7 @@ class AutoEPMoELayer(nn.Module):
             shape=(bsz, seqlen, hdim),
         )
 
-        if self.model_family == "llama4":
+        if self.moe_output_shape == "flat":
             output = output.reshape(-1, hdim)
             shared_expert_input = x
         elif self.shared_experts_gate is not None:

--- a/deepspeed/module_inject/auto_ep_preset_adapters.py
+++ b/deepspeed/module_inject/auto_ep_preset_adapters.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+"""Preset-specific AutoEP parser adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Callable, Literal
+
+import torch.nn as nn
+
+from deepspeed.module_inject.auto_ep_config import AutoEPConfig, MoELayerSpec, MoEModelPreset
+from deepspeed.utils import logger
+
+
+@dataclass(frozen=True)
+class GroupRoutingConfig:
+    num_expert_groups: int | None
+    num_limited_groups: int | None
+    group_score_func: Literal["max", "top2_sum"] = "top2_sum"
+
+
+@dataclass(frozen=True)
+class ForwardContract:
+    return_router_logits: bool = False
+    capture_target: Literal["moe_block", "router", "none"] = "none"
+    capture_index: int | None = None
+    capture_layer_name: str | None = None
+    router_logits_capture_mode: Literal["raw", "post_score"] = "post_score"
+    moe_output_shape: Literal["batched", "flat"] = "batched"
+
+
+class AutoEPPresetAdapter:
+    """Default behavior shared by presets without model-specific parser rules."""
+
+    def resolve_route_norm(
+        self,
+        config: AutoEPConfig,
+        preset: MoEModelPreset,
+        model_config,
+    ) -> bool:
+        if config.route_norm is not None:
+            return config.route_norm
+
+        cfg_norm = getattr(model_config, 'norm_topk_prob', None)
+        if cfg_norm is not None:
+            return bool(cfg_norm)
+        return preset.route_norm
+
+    def resolve_group_routing(
+        self,
+        config: AutoEPConfig,
+        model_config,
+    ) -> GroupRoutingConfig:
+        return GroupRoutingConfig(
+            num_expert_groups=config.num_expert_groups,
+            num_limited_groups=config.num_limited_groups,
+        )
+
+    def adjust_forward_contract(self, contract: ForwardContract) -> ForwardContract:
+        return contract
+
+    def retarget_transformers_output_recorders(
+        self,
+        model: nn.Module,
+        spec: MoELayerSpec,
+        replacement: nn.Module,
+        retargeted_keys: set[str],
+        remove_output_capture_hooks: Callable[[nn.Module], int],
+    ) -> None:
+        return
+
+
+class DeepSeekV2PresetAdapter(AutoEPPresetAdapter):
+    """DeepSeek-V2 keeps native top-k normalization and optional group-limited routing."""
+
+    def resolve_route_norm(
+        self,
+        config: AutoEPConfig,
+        preset: MoEModelPreset,
+        model_config,
+    ) -> bool:
+        if config.route_norm is not None:
+            return config.route_norm
+        return preset.route_norm
+
+    def resolve_group_routing(
+        self,
+        config: AutoEPConfig,
+        model_config,
+    ) -> GroupRoutingConfig:
+        group_routing = super().resolve_group_routing(config, model_config)
+        if getattr(model_config, 'topk_method', None) != "group_limited_greedy":
+            return group_routing
+
+        return GroupRoutingConfig(
+            num_expert_groups=group_routing.num_expert_groups or getattr(model_config, 'n_group', None),
+            num_limited_groups=group_routing.num_limited_groups or getattr(model_config, 'topk_group', None),
+            group_score_func="max",
+        )
+
+
+class DeepSeekV3PresetAdapter(AutoEPPresetAdapter):
+    """DeepSeek-V3 always carries group-limited routing fields when present."""
+
+    def resolve_group_routing(
+        self,
+        config: AutoEPConfig,
+        model_config,
+    ) -> GroupRoutingConfig:
+        group_routing = super().resolve_group_routing(config, model_config)
+        return GroupRoutingConfig(
+            num_expert_groups=group_routing.num_expert_groups or getattr(model_config, 'n_group', None),
+            num_limited_groups=group_routing.num_limited_groups or getattr(model_config, 'topk_group', None),
+            group_score_func=group_routing.group_score_func,
+        )
+
+
+class Qwen35MoePresetAdapter(AutoEPPresetAdapter):
+    """Qwen3.5 MoE exposes router logits through HF output recording."""
+
+    def adjust_forward_contract(self, contract: ForwardContract) -> ForwardContract:
+        # HF records Qwen3.5 router output on Qwen3_5MoeTopKRouter. AutoEP replaces
+        # the owning MoE block, so replacement output index 1 is used for recorder retargeting.
+        return replace(
+            contract,
+            return_router_logits=True,
+            capture_target="router",
+            capture_index=1,
+        )
+
+    def retarget_transformers_output_recorders(
+        self,
+        model: nn.Module,
+        spec: MoELayerSpec,
+        replacement: nn.Module,
+        retargeted_keys: set[str],
+        remove_output_capture_hooks: Callable[[nn.Module], int],
+    ) -> None:
+        recorder_key = f"{spec.model_family}:{replacement.__class__.__module__}.{replacement.__class__.__qualname__}"
+        if recorder_key in retargeted_keys:
+            return
+        retargeted_keys.add(recorder_key)
+
+        try:
+            from transformers.utils.output_capturing import _CAN_RECORD_REGISTRY, OutputRecorder
+        except Exception as exc:
+            logger.warning(f"AutoEP: could not retarget Qwen3.5 router-logit output capture: {exc}")
+            return
+
+        retargeted = 0
+        replacement_cls = replacement.__class__
+        for module in model.modules():
+            module_config = getattr(module, "config", None)
+            model_type = getattr(module_config, "model_type", None)
+            class_name = module.__class__.__name__
+            if model_type != "qwen3_5_moe_text" and "Qwen3_5Moe" not in class_name:
+                continue
+
+            registry_key = str(module.__class__)
+            record_outputs = getattr(module, "_can_record_outputs", None)
+            registry_outputs = _CAN_RECORD_REGISTRY.get(registry_key)
+            base_outputs = record_outputs if isinstance(record_outputs, dict) else registry_outputs
+            if not isinstance(base_outputs, dict) or "router_logits" not in base_outputs:
+                continue
+
+            retargeted_outputs = dict(base_outputs)
+            retargeted_outputs["router_logits"] = OutputRecorder(replacement_cls, index=1)
+            module._can_record_outputs = retargeted_outputs
+            _CAN_RECORD_REGISTRY[registry_key] = retargeted_outputs
+
+            if getattr(module, "_output_capturing_hooks_installed", False):
+                removed = remove_output_capture_hooks(module)
+                if removed:
+                    logger.debug(f"AutoEP: removed {removed} stale HF output-capturing hook(s) "
+                                 f"from {class_name}.")
+            module._output_capturing_hooks_installed = False
+            retargeted += 1
+
+        if retargeted:
+            logger.info("AutoEP: retargeted Qwen3.5 HF router-logit output capture to record "
+                        f"{replacement_cls.__name__} output index 1 on {retargeted} module(s).")
+        else:
+            logger.warning("AutoEP: Qwen3.5 AutoEP conversion did not find a HF output-capture registry "
+                           "entry for router_logits.")
+
+
+class Llama4PresetAdapter(AutoEPPresetAdapter):
+    """Llama4 MoE returns a flat hidden-state tensor with raw router logits."""
+
+    def adjust_forward_contract(self, contract: ForwardContract) -> ForwardContract:
+        capture_target = contract.capture_target
+        if capture_target == "none":
+            capture_target = "router"
+
+        return replace(
+            contract,
+            return_router_logits=True,
+            capture_target=capture_target,
+            router_logits_capture_mode="raw",
+            moe_output_shape="flat",
+        )
+
+
+_PRESET_ADAPTERS: dict[str, AutoEPPresetAdapter] = {
+    "default": AutoEPPresetAdapter(),
+    "deepseek_v2": DeepSeekV2PresetAdapter(),
+    "deepseek_v3": DeepSeekV3PresetAdapter(),
+    "qwen3_5_moe": Qwen35MoePresetAdapter(),
+    "llama4": Llama4PresetAdapter(),
+}
+
+
+def get_preset_adapter(adapter_name: str) -> AutoEPPresetAdapter:
+    adapter = _PRESET_ADAPTERS.get(adapter_name)
+    if adapter is None:
+        raise ValueError(f"Unknown AutoEP preset adapter '{adapter_name}'")
+    return adapter

--- a/deepspeed/moe/ep_router.py
+++ b/deepspeed/moe/ep_router.py
@@ -55,6 +55,7 @@ class TokenChoiceTopKRouter(nn.Module):
         route_norm: bool,
         route_scale: float,
         gate_bias: bool,
+        group_score_func: str = "top2_sum",
     ):
         super().__init__()
         self.gate = nn.Linear(dim, num_experts, bias=gate_bias)
@@ -65,6 +66,7 @@ class TokenChoiceTopKRouter(nn.Module):
         self.score_func = score_func
         self.route_norm = route_norm
         self.route_scale = route_scale
+        self.group_score_func = group_score_func
 
     # ------------------------------------------------------------------
     # Node-limited (group-limited) routing
@@ -93,13 +95,18 @@ class TokenChoiceTopKRouter(nn.Module):
                              f"num_expert_groups ({self.num_expert_groups})")
 
         experts_per_group = self.num_experts // self.num_expert_groups
-        if experts_per_group < 2:
-            raise ValueError(f"experts_per_group ({experts_per_group}) must be >= 2")
 
         scores_grouped = scores_for_choice.view(-1, self.num_expert_groups, experts_per_group)
-        # Score each group by the sum of its top-2 expert scores
-        top2_scores_in_group, _ = scores_grouped.topk(2, dim=-1)
-        group_scores = top2_scores_in_group.sum(dim=-1)
+        if self.group_score_func == "max":
+            group_scores = scores_grouped.max(dim=-1).values
+        elif self.group_score_func == "top2_sum":
+            if experts_per_group < 2:
+                raise ValueError(f"experts_per_group ({experts_per_group}) must be >= 2")
+            # DeepSeek-V3 scores each group by the sum of its top-2 experts.
+            top2_scores_in_group, _ = scores_grouped.topk(2, dim=-1)
+            group_scores = top2_scores_in_group.sum(dim=-1)
+        else:
+            raise NotImplementedError(f"Unknown group score function: {self.group_score_func}")
 
         # Select top groups
         _, group_idx = torch.topk(group_scores, k=self.num_limited_groups, dim=-1, sorted=False)

--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -893,7 +893,7 @@ Configure AutoEP expert parallelism for MoE models. AutoEP automatically detects
 | -------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | Built-in model preset for MoE detection: `mixtral`, `qwen3_moe`, `deepseek_v2`, `deepseek_v3`, `llama4`. Determines router, expert, and weight naming patterns. | `null`  |
 
-DeepSeek-V2 and DeepSeek-V3 forward parity is validated with Transformers 5.x when `load_balance_coeff` is unset or `null`.
+DeepSeek-V2 and DeepSeek-V3 forward parity is validated with Transformers 5.x with AutoEP load-balance expert bias disabled.
 
 ***use_grouped_mm***: [boolean]
 
@@ -977,7 +977,7 @@ DeepSeek-V2 and DeepSeek-V3 forward parity is validated with Transformers 5.x wh
 
 | Description                                                                                          | Default |
 | ---------------------------------------------------------------------------------------------------- | ------- |
-| Coefficient for auxiliary-loss-free load balancing via expert bias. Set to `null` to disable. DeepSeek-V2 and DeepSeek-V3 presets do not support expert bias yet and reject non-null values. | `1e-3`  |
+| Coefficient for auxiliary-loss-free load balancing via expert bias. Set to `null` to disable. DeepSeek-V2 and DeepSeek-V3 presets disable it by default for validated parity and reject explicit non-null values while expert bias is unsupported. | `1e-3`  |
 
 ***expert_w1***: [string]
 

--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -893,6 +893,8 @@ Configure AutoEP expert parallelism for MoE models. AutoEP automatically detects
 | -------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | Built-in model preset for MoE detection: `mixtral`, `qwen3_moe`, `deepseek_v2`, `deepseek_v3`, `llama4`. Determines router, expert, and weight naming patterns. | `null`  |
 
+DeepSeek-V2 and DeepSeek-V3 forward parity is validated with Transformers 5.x when `load_balance_coeff` is unset or `null`.
+
 ***use_grouped_mm***: [boolean]
 
 | Description                                                                                    | Default |
@@ -975,7 +977,7 @@ Configure AutoEP expert parallelism for MoE models. AutoEP automatically detects
 
 | Description                                                                                          | Default |
 | ---------------------------------------------------------------------------------------------------- | ------- |
-| Coefficient for auxiliary-loss-free load balancing via expert bias. Set to `null` to disable.        | `1e-3`  |
+| Coefficient for auxiliary-loss-free load balancing via expert bias. Set to `null` to disable. DeepSeek-V2 and DeepSeek-V3 presets do not support expert bias yet and reject non-null values. | `1e-3`  |
 
 ***expert_w1***: [string]
 

--- a/docs/code-docs/source/moe.rst
+++ b/docs/code-docs/source/moe.rst
@@ -14,7 +14,8 @@ with EP-enabled versions, requiring zero model code changes. It follows the
 pattern of AutoTP (Automatic Tensor Parallelism).
 
 **Supported models:** Mixtral, Qwen3-MoE, DeepSeek-V2, DeepSeek-V3, LLaMA-4
-(via built-in presets).
+(via built-in presets). DeepSeek-V2 and DeepSeek-V3 forward parity is validated
+with Transformers 5.x when ``load_balance_coeff`` is unset or ``null``.
 
 **ZeRO compatibility:** Stages 0, 1, and 2. Stage 3 is not supported.
 
@@ -47,3 +48,6 @@ pattern of AutoTP (Automatic Tensor Parallelism).
   for functional testing on a single GPU.
 - AutoTP and sequence parallelism cannot both be active simultaneously.
 - Checkpoint save/load requires matching ``autoep_size``.
+- DeepSeek-V2 and DeepSeek-V3 AutoEP do not support load-balance expert bias
+  yet. Set ``load_balance_coeff`` to ``null`` or leave it unset for those
+  presets; non-null values fail explicitly.

--- a/docs/code-docs/source/moe.rst
+++ b/docs/code-docs/source/moe.rst
@@ -15,7 +15,7 @@ pattern of AutoTP (Automatic Tensor Parallelism).
 
 **Supported models:** Mixtral, Qwen3-MoE, DeepSeek-V2, DeepSeek-V3, LLaMA-4
 (via built-in presets). DeepSeek-V2 and DeepSeek-V3 forward parity is validated
-with Transformers 5.x when ``load_balance_coeff`` is unset or ``null``.
+with Transformers 5.x with AutoEP load-balance expert bias disabled.
 
 **ZeRO compatibility:** Stages 0, 1, and 2. Stage 3 is not supported.
 
@@ -49,5 +49,5 @@ with Transformers 5.x when ``load_balance_coeff`` is unset or ``null``.
 - AutoTP and sequence parallelism cannot both be active simultaneously.
 - Checkpoint save/load requires matching ``autoep_size``.
 - DeepSeek-V2 and DeepSeek-V3 AutoEP do not support load-balance expert bias
-  yet. Set ``load_balance_coeff`` to ``null`` or leave it unset for those
-  presets; non-null values fail explicitly.
+  yet. The built-in DeepSeek presets disable it by default; explicit non-null
+  values fail.

--- a/tests/unit/moe/test_autoep_unit.py
+++ b/tests/unit/moe/test_autoep_unit.py
@@ -5,6 +5,7 @@
 """Unit tests for AutoEP feature (all phases append test classes here)."""
 
 import copy
+from pathlib import Path
 
 import pytest
 import torch
@@ -89,6 +90,12 @@ class TestAutoEPConfig:
 
         assert resolved.load_balance_coeff is None
         assert config.load_balance_coeff == pytest.approx(1e-3)
+
+    def test_deepseek_presets_mark_expert_bias_unsupported(self):
+        assert PRESET_MODELS["deepseek_v2"].supports_expert_bias is False
+        assert PRESET_MODELS["deepseek_v3"].supports_expert_bias is False
+        assert PRESET_MODELS["deepseek_v2"].unsupported_router_bias_names == ()
+        assert PRESET_MODELS["deepseek_v3"].unsupported_router_bias_names == ("e_score_correction_bias", )
 
     def test_parse_autoep_config_full(self):
         """All fields parsed from complete JSON."""
@@ -825,6 +832,7 @@ class TestMoEDetection:
         })
         auto_ep = AutoEP(model, config)
         specs = auto_ep.ep_parser()
+        assert specs[0].supports_expert_bias is False
         auto_ep.replace_moe_layer(specs[0], ep_size=1, ep_rank=0)
 
         replaced = model.model.layers[0].mlp
@@ -845,8 +853,9 @@ class TestMoEDetection:
         })
         auto_ep = AutoEP(model, config)
         specs = auto_ep.ep_parser()
+        assert specs[0].supports_expert_bias is False
 
-        with pytest.raises(ValueError, match="DeepSeek.*load_balance_coeff"):
+        with pytest.raises(ValueError, match="load_balance_coeff/expert_bias"):
             auto_ep.replace_moe_layer(specs[0], ep_size=1, ep_rank=0)
 
     def test_deepseek_v3_nonzero_score_correction_bias_rejected(self):
@@ -862,6 +871,7 @@ class TestMoEDetection:
         })
         auto_ep = AutoEP(model, config)
         specs = auto_ep.ep_parser()
+        assert specs[0].unsupported_router_bias_names == ("e_score_correction_bias", )
 
         with pytest.raises(ValueError, match="e_score_correction_bias"):
             auto_ep.replace_moe_layer(specs[0], ep_size=1, ep_rank=0)
@@ -1314,6 +1324,33 @@ class TestAutoEPMoELayerUnit:
         config = AutoEPConfig(enabled=True, autoep_size=1)
         layer = AutoEPMoELayer(spec, source, ep_size=1, ep_rank=0, config=config)
         assert layer._is_autoep_layer is True
+
+    def test_autoep_layer_has_no_deepseek_preset_hardcode(self):
+        layer_path = Path(__file__).resolve().parents[3] / "deepspeed" / "module_inject" / "auto_ep_layer.py"
+        layer_source = layer_path.read_text()
+        assert "_DEEPSEEK_PRESETS" not in layer_source
+        assert "deepseek_v2" not in layer_source
+        assert "deepseek_v3" not in layer_source
+
+    def test_spec_can_disable_expert_bias_without_model_family_branch(self):
+        source = MockMoEBlock(num_experts=4, ffn_hidden=128, hidden_size=64)
+        spec = _make_spec(model_family="custom_no_expert_bias", supports_expert_bias=False)
+        config = AutoEPConfig(enabled=True, autoep_size=1, load_balance_coeff=0.02)
+
+        with pytest.raises(ValueError, match="custom_no_expert_bias.*load_balance_coeff/expert_bias"):
+            AutoEPMoELayer(spec, source, ep_size=1, ep_rank=0, config=config)
+
+    def test_spec_unsupported_router_bias_name_rejects_nonzero_buffer(self):
+        source = MockMoEBlock(num_experts=4, ffn_hidden=128, hidden_size=64)
+        source.gate.register_buffer("source_router_bias", torch.ones(4))
+        spec = _make_spec(
+            model_family="custom_router_bias",
+            unsupported_router_bias_names=("source_router_bias", ),
+        )
+        config = AutoEPConfig(enabled=True, autoep_size=1, load_balance_coeff=None)
+
+        with pytest.raises(ValueError, match="source_router_bias"):
+            AutoEPMoELayer(spec, source, ep_size=1, ep_rank=0, config=config)
 
     def test_autoep_layer_ep_size_1_forward(self):
         torch.manual_seed(42)

--- a/tests/unit/moe/test_autoep_unit.py
+++ b/tests/unit/moe/test_autoep_unit.py
@@ -5,6 +5,7 @@
 """Unit tests for AutoEP feature (all phases append test classes here)."""
 
 import copy
+import re
 from pathlib import Path
 
 import pytest
@@ -300,6 +301,10 @@ class TestAutoEPConfig:
         assert qwen2.has_shared_experts is True
         assert qwen2.shared_experts_pattern == "shared_expert"
         assert qwen2.shared_experts_gate_pattern == "shared_expert_gate"
+        assert qwen2.preset_adapter == "default"
+
+        qwen3_5 = PRESET_MODELS["qwen3_5_moe"]
+        assert qwen3_5.preset_adapter == "qwen3_5_moe"
 
     def test_validate_empty_expert_w1(self):
         """Empty expert_w1 raises ValueError."""
@@ -753,6 +758,8 @@ class TestMoEDetection:
             assert spec.router_name == "router"
             assert spec.return_router_logits is True
             assert spec.router_logits_capture_target == "router"
+            assert spec.router_logits_capture_mode == "raw"
+            assert spec.moe_output_shape == "flat"
             assert spec.has_shared_experts is True
             assert spec.shared_experts_name == "shared_expert"
 
@@ -767,6 +774,8 @@ class TestMoEDetection:
         assert len(specs) == 1
         assert specs[0].return_router_logits is True
         assert specs[0].router_logits_capture_target == "router"
+        assert specs[0].router_logits_capture_mode == "raw"
+        assert specs[0].moe_output_shape == "flat"
 
     def test_llama4_preset_layer_disables_expert_bias_by_default(self):
         """preset_model='llama4' resolves load_balance_coeff=None for layer construction."""
@@ -892,6 +901,26 @@ class TestMoEDetection:
         assert len(specs) == 1
         assert specs[0].route_norm is False
 
+    def test_deepseek_v2_detection_reads_group_limited_routing_from_model_config(self):
+        """DeepSeek-V2 group_limited_greedy routing uses max group scoring."""
+        model = MockMoETransformer(num_layers=1, num_experts=4, moe_every_n=1)
+        model.config.topk_method = "group_limited_greedy"
+        model.config.n_group = 2
+        model.config.topk_group = 1
+        config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+            "preset_model": "deepseek_v2",
+            "top_k": 2,
+        })
+
+        specs = AutoEP(model, config).ep_parser()
+
+        assert len(specs) == 1
+        assert specs[0].num_expert_groups == 2
+        assert specs[0].num_limited_groups == 1
+        assert specs[0].group_score_func == "max"
+
     def test_deepseek_v3_detection_reads_group_routing_from_model_config(self):
         """DeepSeek-V3 preset carries HF group-limited routing into AutoEP."""
         model = MockMoETransformer(num_layers=1, num_experts=4, moe_every_n=1)
@@ -913,6 +942,24 @@ class TestMoEDetection:
         assert specs[0].num_limited_groups == 1
         assert specs[0].group_score_func == "top2_sum"
         assert specs[0].route_scale == pytest.approx(2.5)
+
+    def test_qwen3_5_moe_adapter_sets_router_capture_contract(self):
+        """Qwen3.5 records router output through the AutoEP replacement tuple."""
+        model = MockMoETransformer(num_layers=1, num_experts=4, moe_every_n=1)
+        model.config.num_experts = 4
+        config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+            "preset_model": "qwen3_5_moe",
+        })
+
+        specs = AutoEP(model, config).ep_parser()
+
+        assert len(specs) == 1
+        assert specs[0].return_router_logits is True
+        assert specs[0].router_logits_capture_target == "router"
+        assert specs[0].router_logits_capture_index == 1
+        assert specs[0].router_logits_capture_mode == "post_score"
 
     def test_replace_moe_layer_works(self):
         """replace_moe_layer creates AutoEPMoELayer replacement."""
@@ -1325,12 +1372,19 @@ class TestAutoEPMoELayerUnit:
         layer = AutoEPMoELayer(spec, source, ep_size=1, ep_rank=0, config=config)
         assert layer._is_autoep_layer is True
 
-    def test_autoep_layer_has_no_deepseek_preset_hardcode(self):
+    def test_autoep_layer_has_no_model_family_literal_hardcode(self):
         layer_path = Path(__file__).resolve().parents[3] / "deepspeed" / "module_inject" / "auto_ep_layer.py"
         layer_source = layer_path.read_text()
         assert "_DEEPSEEK_PRESETS" not in layer_source
-        assert "deepseek_v2" not in layer_source
-        assert "deepseek_v3" not in layer_source
+        for model_family in ("deepseek_v2", "deepseek_v3", "qwen3_5_moe", "llama4"):
+            assert model_family not in layer_source
+
+    def test_autoep_parser_has_no_model_family_behavior_branches(self):
+        auto_ep_path = Path(__file__).resolve().parents[3] / "deepspeed" / "module_inject" / "auto_ep.py"
+        auto_ep_source = auto_ep_path.read_text()
+        for model_family in ("deepseek_v2", "deepseek_v3", "qwen3_5_moe", "llama4"):
+            assert not re.search(rf"(preset_name|spec\.model_family)\s*[!=]=\s*['\"]{model_family}['\"]",
+                                 auto_ep_source)
 
     def test_spec_can_disable_expert_bias_without_model_family_branch(self):
         source = MockMoEBlock(num_experts=4, ffn_hidden=128, hidden_size=64)

--- a/tests/unit/moe/test_autoep_unit.py
+++ b/tests/unit/moe/test_autoep_unit.py
@@ -79,6 +79,17 @@ class TestAutoEPConfig:
 
         assert resolved.load_balance_coeff == pytest.approx(0.02)
 
+    @pytest.mark.parametrize("preset_model", ["deepseek_v2", "deepseek_v3"])
+    def test_deepseek_preset_default_sets_load_balance_coeff_none(self, preset_model):
+        """DeepSeek presets disable AutoEP expert_bias by default."""
+        config = parse_autoep_config({"enabled": True, "preset_model": preset_model})
+        assert config.load_balance_coeff == pytest.approx(1e-3)
+
+        resolved = resolve_autoep_config_defaults(config, config.preset_model)
+
+        assert resolved.load_balance_coeff is None
+        assert config.load_balance_coeff == pytest.approx(1e-3)
+
     def test_parse_autoep_config_full(self):
         """All fields parsed from complete JSON."""
         param_dict = {
@@ -802,6 +813,97 @@ class TestMoEDetection:
         assert replaced.load_balance_coeff is None
         assert replaced.expert_bias is None
 
+    @pytest.mark.parametrize("preset_model", ["deepseek_v2", "deepseek_v3"])
+    def test_deepseek_preset_layer_disables_expert_bias_by_default(self, preset_model):
+        """DeepSeek preset defaults resolve to no AutoEP load-balance expert_bias."""
+        model = MockMoETransformer(num_layers=1, num_experts=4, moe_every_n=1)
+        config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+            "preset_model": preset_model,
+            "top_k": 2,
+        })
+        auto_ep = AutoEP(model, config)
+        specs = auto_ep.ep_parser()
+        auto_ep.replace_moe_layer(specs[0], ep_size=1, ep_rank=0)
+
+        replaced = model.model.layers[0].mlp
+        assert replaced.load_balance_coeff is None
+        assert replaced.expert_bias is None
+        assert "expert_bias" not in dict(replaced.named_buffers())
+
+    @pytest.mark.parametrize("preset_model", ["deepseek_v2", "deepseek_v3"])
+    def test_deepseek_explicit_load_balance_coeff_rejected(self, preset_model):
+        """DeepSeek AutoEP fails explicitly instead of creating expert_bias."""
+        model = MockMoETransformer(num_layers=1, num_experts=4, moe_every_n=1)
+        config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+            "preset_model": preset_model,
+            "top_k": 2,
+            "load_balance_coeff": 0.02,
+        })
+        auto_ep = AutoEP(model, config)
+        specs = auto_ep.ep_parser()
+
+        with pytest.raises(ValueError, match="DeepSeek.*load_balance_coeff"):
+            auto_ep.replace_moe_layer(specs[0], ep_size=1, ep_rank=0)
+
+    def test_deepseek_v3_nonzero_score_correction_bias_rejected(self):
+        """DeepSeek-V3 expert correction bias remains unsupported for AutoEP parity."""
+        model = MockMoETransformer(num_layers=1, num_experts=4, moe_every_n=1)
+        model.model.layers[0].mlp.gate.register_buffer("e_score_correction_bias", torch.ones(4))
+        config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+            "preset_model": "deepseek_v3",
+            "top_k": 2,
+            "load_balance_coeff": None,
+        })
+        auto_ep = AutoEP(model, config)
+        specs = auto_ep.ep_parser()
+
+        with pytest.raises(ValueError, match="e_score_correction_bias"):
+            auto_ep.replace_moe_layer(specs[0], ep_size=1, ep_rank=0)
+
+    def test_deepseek_v2_detection_keeps_native_topk_weights_unnormalized(self):
+        """DeepSeek-V2 HF forward does not renormalize top-k weights in Transformers 5."""
+        model = MockMoETransformer(num_layers=1, num_experts=4, moe_every_n=1)
+        model.config.norm_topk_prob = True
+        config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+            "preset_model": "deepseek_v2",
+            "top_k": 2,
+        })
+
+        specs = AutoEP(model, config).ep_parser()
+
+        assert len(specs) == 1
+        assert specs[0].route_norm is False
+
+    def test_deepseek_v3_detection_reads_group_routing_from_model_config(self):
+        """DeepSeek-V3 preset carries HF group-limited routing into AutoEP."""
+        model = MockMoETransformer(num_layers=1, num_experts=4, moe_every_n=1)
+        model.config.n_group = 2
+        model.config.topk_group = 1
+        model.config.norm_topk_prob = True
+        model.config.routed_scaling_factor = 2.5
+        config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+            "preset_model": "deepseek_v3",
+            "top_k": 2,
+        })
+
+        specs = AutoEP(model, config).ep_parser()
+
+        assert len(specs) == 1
+        assert specs[0].num_expert_groups == 2
+        assert specs[0].num_limited_groups == 1
+        assert specs[0].group_score_func == "top2_sum"
+        assert specs[0].route_scale == pytest.approx(2.5)
+
     def test_replace_moe_layer_works(self):
         """replace_moe_layer creates AutoEPMoELayer replacement."""
         from deepspeed.module_inject.auto_ep_layer import AutoEPMoELayer as _AutoEPMoELayer
@@ -1189,6 +1291,20 @@ class TestParamMarking:
             assert hasattr(p, 'allreduce') and p.allreduce is True
 
 
+def _require_transformers_5(transformers):
+    from packaging.version import Version
+    if Version(transformers.__version__) < Version("5.0.0"):
+        pytest.skip("DeepSeek AutoEP parity smoke requires Transformers >= 5.0.0")
+
+
+def _get_transformers_class(transformers, *names):
+    for name in names:
+        cls = getattr(transformers, name, None)
+        if cls is not None:
+            return cls
+    pytest.skip(f"Installed transformers does not expose any of: {names}")
+
+
 class TestAutoEPMoELayerUnit:
     """Phase 5 tests for AutoEPMoELayer (ep_size=1, no dist needed)."""
 
@@ -1331,6 +1447,135 @@ class TestAutoEPMoELayerUnit:
         assert len(autoep_layers) == 1
         assert autoep_layers[0].shared_experts is None
         assert autoep_layers[0].shared_experts_gate is None
+
+        input_ids = torch.tensor([[1, 5, 7, 9, 11]], dtype=torch.long)
+        labels = input_ids.clone()
+        native_model.eval()
+        autoep_model.eval()
+        with torch.no_grad():
+            native_outputs = native_model(input_ids=input_ids, labels=labels, output_router_logits=False)
+            autoep_outputs = autoep_model(input_ids=input_ids, labels=labels, output_router_logits=False)
+
+        torch.testing.assert_close(autoep_outputs.logits, native_outputs.logits, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(autoep_outputs.loss, native_outputs.loss, rtol=1e-5, atol=1e-6)
+
+    def test_hf_deepseek_v2_causal_lm_matches_autoep_without_load_balance_default(self):
+        """Tiny DeepSeek-V2 CausalLM reaches forward parity after AutoEP replacement."""
+        transformers = pytest.importorskip("transformers")
+        _require_transformers_5(transformers)
+        config_cls = _get_transformers_class(transformers, "DeepseekV2Config", "DeepSeekV2Config")
+        model_cls = _get_transformers_class(transformers, "DeepseekV2ForCausalLM", "DeepSeekV2ForCausalLM")
+
+        torch.manual_seed(1234)
+        config = config_cls(
+            vocab_size=64,
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            max_position_embeddings=64,
+            first_k_dense_replace=0,
+            moe_layer_freq=1,
+            moe_intermediate_size=16,
+            n_routed_experts=4,
+            n_shared_experts=0,
+            num_experts_per_tok=2,
+            norm_topk_prob=True,
+            scoring_func="softmax",
+            routed_scaling_factor=1.0,
+            output_router_logits=False,
+            tie_word_embeddings=False,
+            use_cache=False,
+        )
+        native_model = model_cls(config)
+        autoep_model = model_cls(config)
+        autoep_model.load_state_dict(copy.deepcopy(native_model.state_dict()))
+
+        autoep_config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+            "preset_model": "deepseek_v2",
+            "use_grouped_mm": False,
+        })
+        auto_ep = AutoEP(autoep_model, autoep_config)
+        specs = auto_ep.ep_parser()
+        assert len(specs) == 1
+        assert specs[0].model_family == "deepseek_v2"
+        assert specs[0].route_norm is False
+        for spec in specs:
+            auto_ep.replace_moe_layer(spec, ep_size=1, ep_rank=0)
+
+        autoep_layers = [module for module in autoep_model.modules() if isinstance(module, AutoEPMoELayer)]
+        assert len(autoep_layers) == 1
+        assert autoep_layers[0].load_balance_coeff is None
+        assert autoep_layers[0].expert_bias is None
+
+        input_ids = torch.tensor([[1, 5, 7, 9, 11]], dtype=torch.long)
+        labels = input_ids.clone()
+        native_model.eval()
+        autoep_model.eval()
+        with torch.no_grad():
+            native_outputs = native_model(input_ids=input_ids, labels=labels, output_router_logits=False)
+            autoep_outputs = autoep_model(input_ids=input_ids, labels=labels, output_router_logits=False)
+
+        torch.testing.assert_close(autoep_outputs.logits, native_outputs.logits, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(autoep_outputs.loss, native_outputs.loss, rtol=1e-5, atol=1e-6)
+
+    def test_hf_deepseek_v3_causal_lm_matches_autoep_without_load_balance_default(self):
+        """Tiny DeepSeek-V3 CausalLM reaches forward parity after AutoEP replacement."""
+        transformers = pytest.importorskip("transformers")
+        _require_transformers_5(transformers)
+        config_cls = _get_transformers_class(transformers, "DeepseekV3Config", "DeepSeekV3Config")
+        model_cls = _get_transformers_class(transformers, "DeepseekV3ForCausalLM", "DeepSeekV3ForCausalLM")
+
+        torch.manual_seed(1234)
+        config = config_cls(
+            vocab_size=64,
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            max_position_embeddings=64,
+            first_k_dense_replace=0,
+            moe_layer_freq=1,
+            moe_intermediate_size=16,
+            n_routed_experts=4,
+            n_shared_experts=0,
+            num_experts_per_tok=2,
+            norm_topk_prob=True,
+            scoring_func="sigmoid",
+            routed_scaling_factor=1.0,
+            n_group=2,
+            topk_group=1,
+            output_router_logits=False,
+            tie_word_embeddings=False,
+            use_cache=False,
+        )
+        native_model = model_cls(config)
+        autoep_model = model_cls(config)
+        autoep_model.load_state_dict(copy.deepcopy(native_model.state_dict()))
+
+        autoep_config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+            "preset_model": "deepseek_v3",
+            "use_grouped_mm": False,
+        })
+        auto_ep = AutoEP(autoep_model, autoep_config)
+        specs = auto_ep.ep_parser()
+        assert len(specs) == 1
+        assert specs[0].model_family == "deepseek_v3"
+        assert specs[0].num_expert_groups == 2
+        assert specs[0].num_limited_groups == 1
+        for spec in specs:
+            auto_ep.replace_moe_layer(spec, ep_size=1, ep_rank=0)
+
+        autoep_layers = [module for module in autoep_model.modules() if isinstance(module, AutoEPMoELayer)]
+        assert len(autoep_layers) == 1
+        assert autoep_layers[0].load_balance_coeff is None
+        assert autoep_layers[0].expert_bias is None
 
         input_ids = torch.tensor([[1, 5, 7, 9, 11]], dtype=torch.long)
         labels = input_ids.clone()


### PR DESCRIPTION
## Summary

Implements tohtana/dev_ds#99 for the AutoEP PR #7938 staging branch.

- disables AutoEP load-balance `expert_bias` by default for DeepSeek-V2 and DeepSeek-V3 presets and rejects non-null `load_balance_coeff` explicitly
- matches Transformers 5.x DeepSeek routing behavior: DeepSeek-V2 keeps native top-k weights unnormalized, while DeepSeek-V3 inherits group-limited routing from the HF config
- adds tiny HF forward parity tests that require replacement success and strict logits/loss parity for DeepSeek-V2 and DeepSeek-V3
- updates AutoEP docs to describe DeepSeek Transformers 5.x parity and the current expert-bias limitation

## Validation

Transformers 5.x validation used `/mnt/local_storage/dev_ds_venvs/autoep-deepseek-tf5` with Transformers 5.8.1.

- `PYTHONPATH=$PWD /mnt/local_storage/dev_ds_venvs/autoep-deepseek-tf5/bin/python -m pytest -q tests/unit/moe/test_autoep_unit.py -k deepseek` -> 11 passed
- `PYTHONPATH=$PWD /mnt/local_storage/dev_ds_venvs/autoep-deepseek-tf5/bin/python -m pytest -q tests/unit/moe/test_autoep_unit.py::TestTokenChoiceTopKRouter` -> 6 passed
- `PYTHONPATH=$PWD /mnt/local_storage/dev_ds_venvs/autoep-deepseek-tf5/bin/python -m pytest -q tests/unit/moe/test_autoep_unit.py -k 'hf_qwen or hf_llama4'` -> 4 passed
- adapted `/mnt/user_storage/deepspeed_pr7938_review/probes/autoep_transformers_matrix/probe_autoep_transformers_matrix.py` for DeepSeek V2/V3 with valid V3 group routing -> replacement and forward parity both `ok: true`
- `pre-commit run --files deepspeed/module_inject/auto_ep.py deepspeed/module_inject/auto_ep_config.py deepspeed/module_inject/auto_ep_layer.py deepspeed/moe/ep_router.py docs/_pages/config-json.md docs/code-docs/source/moe.rst tests/unit/moe/test_autoep_unit.py` -> passed