### PR TITLE
Disable unsupported AutoEP expert bias

### DIFF
--- a/deepspeed/module_inject/auto_ep_config.py
+++ b/deepspeed/module_inject/auto_ep_config.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import copy
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any, Literal, NoReturn
 
 from deepspeed.utils import logger
 
@@ -16,6 +16,14 @@ from deepspeed.utils import logger
 # Unlike None (which means "fused gate+up, no separate w3"), _UNSET means
 # the user did not set the field at all.  Compare with `is _UNSET`.
 _UNSET = object()
+
+
+def _raise_unsupported_load_balance_coeff(value: object) -> NoReturn:
+    raise ValueError(f"load_balance_coeff={value!r} is not supported in this AutoEP build "
+                     "(would register expert_bias and route through unsupported "
+                     "auxiliary-loss-free load balancing). Set load_balance_coeff to null "
+                     "or omit the key.")
+
 
 # ---------------------------------------------------------------------------
 # Dataclasses
@@ -125,7 +133,7 @@ class AutoEPConfig:
 
     def __post_init__(self) -> None:
         if self.load_balance_coeff is _UNSET:
-            self.load_balance_coeff = 1e-3
+            self.load_balance_coeff = None
             self._load_balance_coeff_explicit = False
         else:
             self._load_balance_coeff_explicit = True
@@ -334,10 +342,13 @@ def parse_autoep_config(param_dict: dict) -> AutoEPConfig:
     config.score_func = param_dict.get("score_func", "auto")
     config.top_k = param_dict.get("top_k", "auto")
     if "load_balance_coeff" in param_dict:
-        config.load_balance_coeff = param_dict["load_balance_coeff"]
+        value = param_dict["load_balance_coeff"]
+        if value is not None:
+            _raise_unsupported_load_balance_coeff(value)
+        config.load_balance_coeff = None
         config._load_balance_coeff_explicit = True
     else:
-        config.load_balance_coeff = 1e-3
+        config.load_balance_coeff = None
         config._load_balance_coeff_explicit = False
     config.routed_scaling_factor = param_dict.get("routed_scaling_factor", "auto")
     config.expert_w1 = param_dict.get("expert_w1", None)
@@ -369,6 +380,9 @@ def validate_autoep_config(
     sp_size: int,
 ) -> None:
     """Validate config constraints. Raises ValueError on invalid config."""
+    if config.load_balance_coeff is not None:
+        _raise_unsupported_load_balance_coeff(config.load_balance_coeff)
+
     if not config.enabled:
         return
 

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -4022,7 +4022,8 @@ class DeepSpeedEngine(Module):
         """Remove expert-param keys from state dict, keeping all non-expert params.
 
         Handles both native MoE (deepspeed_moe.experts.*) and AutoEP (experts.w1/w2/w3).
-        Preserves: router weights, shared_experts, expert_bias, all non-MoE params.
+        Preserves: router weights, shared_experts, any legacy/manually-built
+        expert_bias keys, all non-MoE params.
         """
         try:
             from deepspeed.module_inject.auto_ep_layer import AutoEPMoELayer as _AutoEPMoELayer

--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -979,11 +979,11 @@ smoke coverage used for this AutoEP surface produced the following version gates
 | -------------------------------------------------------------------------------------------------- | ------- |
 | Number of groups to select from in group-limited routing. Must be <= `num_expert_groups` when set.  | `null`  |
 
-***load_balance_coeff***: [float]
+***load_balance_coeff***: [null]
 
 | Description                                                                                          | Default |
 | ---------------------------------------------------------------------------------------------------- | ------- |
-| Coefficient for auxiliary-loss-free load balancing via expert bias. Set to `null` to disable. DeepSeek-V2 and DeepSeek-V3 presets disable it by default for validated parity and reject explicit non-null values while expert bias is unsupported. | `1e-3`  |
+| Reserved for future auxiliary-loss-free load balancing via `expert_bias`. Currently unsupported - must be unset or `null`; any other value is rejected. | `null`  |
 
 ***expert_w1***: [string]
 

--- a/tests/unit/moe/test_autoep_checkpoint.py
+++ b/tests/unit/moe/test_autoep_checkpoint.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 import deepspeed
 import deepspeed.comm as dist
 from deepspeed.accelerator import get_accelerator
+from deepspeed.runtime.config import DeepSpeedConfig
 from unit.common import DistributedTest
 
 # ---------------------------------------------------------------------------
@@ -83,6 +84,13 @@ class MockMoETransformer(nn.Module):
 _UNSET = object()
 
 
+def _assert_load_balance_coeff_rejection_message(exc: BaseException, value: object) -> None:
+    text = str(exc)
+    for needle in ("load_balance_coeff", "expert_bias", "not supported", "null", "omit"):
+        assert needle in text
+    assert repr(value) in text
+
+
 def _mixed_precision_config():
     """Return a supported mixed-precision config for the current accelerator."""
     accelerator = get_accelerator()
@@ -108,8 +116,10 @@ def _mixed_precision_config():
 def _make_autoep_config(zero_stage=0, ep_size=1, load_balance_coeff=_UNSET):
     """Build a DeepSpeed config dict for AutoEP checkpoint tests.
 
-    load_balance_coeff: default _UNSET keeps the AutoEP default (1e-3).
-    Pass None to explicitly disable load balancing (no expert_bias).
+    load_balance_coeff: default _UNSET omits the key, which disables
+    load balancing. Pass None to exercise the explicit-null disabled path.
+    Non-None values are retained only for rejection tests and fail during
+    DeepSpeed config parsing or initialize.
     Uses a supported mixed-precision mode because the MoE checkpoint load
     path requires fp16 or bf16.
     """
@@ -160,6 +170,44 @@ def _init_engine(ep_size=1, zero_stage=0, load_balance_coeff=_UNSET):
     return engine
 
 
+@pytest.mark.parametrize("enabled", [True, False])
+@pytest.mark.parametrize("include_key", [False, True])
+def test_load_balance_coeff_disabled_values_accepted_by_deepspeed_config(enabled, include_key):
+    config = {
+        "train_micro_batch_size_per_gpu": 1,
+        "expert_parallel": {
+            "enabled": enabled,
+            "autoep_size": 1,
+            "preset_model": "mixtral",
+        },
+    }
+    if include_key:
+        config["expert_parallel"]["load_balance_coeff"] = None
+
+    ds_config = DeepSpeedConfig(config)
+
+    assert ds_config.expert_parallel_config.load_balance_coeff is None
+    assert ds_config.expert_parallel_config._load_balance_coeff_explicit is include_key
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+@pytest.mark.parametrize("value", [0, 1e-3, 0.02, False, True, "1e-3"])
+def test_load_balance_coeff_rejected_by_deepspeed_config(enabled, value):
+    config = {
+        "train_micro_batch_size_per_gpu": 1,
+        "expert_parallel": {
+            "enabled": enabled,
+            "autoep_size": 1,
+            "preset_model": "mixtral",
+            "load_balance_coeff": value,
+        },
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        DeepSpeedConfig(config)
+    _assert_load_balance_coeff_rejection_message(exc_info.value, value)
+
+
 # ---------------------------------------------------------------------------
 # Phase 1 Tests: Non-MoE State Dict Filter
 # ---------------------------------------------------------------------------
@@ -169,7 +217,7 @@ class TestNonMoeStateDictFilter(DistributedTest):
     world_size = 1
 
     def test_non_moe_state_dict_filter_autoep(self):
-        """Verify filter keeps router, shared_experts, expert_bias; removes w1/w2/w3."""
+        """Verify filter keeps router/shared_experts and removes w1/w2/w3."""
         engine = _init_engine(ep_size=1)
         from deepspeed.module_inject.auto_ep_layer import AutoEPMoELayer
 
@@ -267,24 +315,19 @@ class TestNonMoeStateDictFilter(DistributedTest):
         assert 'model.layers.10.fake_expert_key' in filtered_sd, \
             "Filter incorrectly removed key from non-existent layer 10"
 
-    def test_expert_bias_presence(self):
-        """Save with load_balance_coeff set (default 1e-3) -> expert_bias in main checkpoint."""
-        engine = _init_engine(ep_size=1)  # default has load_balance_coeff=1e-3
-        full_sd = engine.module.state_dict()
-        bias_keys = [k for k in full_sd.keys() if 'expert_bias' in k]
-        assert len(bias_keys) > 0, "Expected expert_bias keys when load_balance_coeff is set"
-
-        filtered_sd = engine._get_non_moe_state_dict(copy.copy(full_sd))
-        for key in bias_keys:
-            assert key in filtered_sd, f"expert_bias key {key} should be preserved in main checkpoint"
-
-    def test_expert_bias_absence(self):
-        """Save with load_balance_coeff=None -> no expert_bias key."""
-        engine = _init_engine(ep_size=1, load_balance_coeff=None)
+    @pytest.mark.parametrize("include_key", [False, True])
+    def test_expert_bias_absent_by_default(self, include_key):
+        """Omitted and explicit-null load_balance_coeff do not register expert_bias."""
+        lbc = None if include_key else _UNSET
+        engine = _init_engine(ep_size=1, load_balance_coeff=lbc)
         full_sd = engine.module.state_dict()
         bias_keys = [k for k in full_sd.keys() if 'expert_bias' in k]
         assert len(bias_keys) == 0, \
-            f"Did not expect expert_bias keys with load_balance_coeff=None, found: {bias_keys}"
+            f"Did not expect expert_bias keys with load_balance_coeff={lbc!r}, found: {bias_keys}"
+
+        filtered_sd = engine._get_non_moe_state_dict(copy.copy(full_sd))
+        filtered_bias_keys = [k for k in filtered_sd.keys() if 'expert_bias' in k]
+        assert filtered_bias_keys == []
 
 
 # ---------------------------------------------------------------------------
@@ -1054,11 +1097,11 @@ class TestAutoEPUniversalLoadGuard(DistributedTest):
         }
 
         class FakeLoader:
+
             def load(self, *args, **kwargs):
                 return os.path.join(str(tmpdir), "mp_rank_00_model_states.pt"), checkpoint, None
 
-        monkeypatch.setattr(SDLoaderFactory, "get_sd_loader",
-                            staticmethod(lambda *args, **kwargs: FakeLoader()))
+        monkeypatch.setattr(SDLoaderFactory, "get_sd_loader", staticmethod(lambda *args, **kwargs: FakeLoader()))
 
         engine = object.__new__(DeepSpeedEngine)
         nn.Module.__init__(engine)

--- a/tests/unit/moe/test_autoep_unit.py
+++ b/tests/unit/moe/test_autoep_unit.py
@@ -28,6 +28,15 @@ from deepspeed.module_inject.auto_ep_config import (
     _UNSET,
 )
 
+_UNSUPPORTED_LOAD_BALANCE_VALUES = [0, 0.0, 1e-3, 0.02, False, True, "1e-3", [1e-3], {"coeff": 1e-3}]
+
+
+def _assert_load_balance_coeff_rejection_message(exc: BaseException, value: object) -> None:
+    text = str(exc)
+    for needle in ("load_balance_coeff", "expert_bias", "not supported", "null", "omit"):
+        assert needle in text
+    assert repr(value) in text
+
 
 class TestAutoEPConfig:
     """Phase 1 unit tests for configuration parsing and validation."""
@@ -49,7 +58,8 @@ class TestAutoEPConfig:
         assert config.num_limited_groups is None
         assert config.score_func == "auto"
         assert config.top_k == "auto"
-        assert config.load_balance_coeff == pytest.approx(1e-3)
+        assert config.load_balance_coeff is None
+        assert config._load_balance_coeff_explicit is False
         assert config.routed_scaling_factor == "auto"
         assert config.expert_w1 is None
         assert config.expert_w2 is None
@@ -61,37 +71,36 @@ class TestAutoEPConfig:
         assert config.shared_experts_gate_pattern is None
 
     def test_llama4_preset_default_sets_load_balance_coeff_none(self):
-        """Llama4 preset disables dynamic expert_bias unless the user opts in."""
+        """Llama4 preset remains disabled if the global default flips back."""
         config = parse_autoep_config({"enabled": True, "preset_model": "llama4"})
-        assert config.load_balance_coeff == pytest.approx(1e-3)
+        assert config.load_balance_coeff is None
 
         resolved = resolve_autoep_config_defaults(config, config.preset_model)
 
         assert resolved.load_balance_coeff is None
-        assert config.load_balance_coeff == pytest.approx(1e-3)
+        assert config.load_balance_coeff is None
 
-    def test_llama4_explicit_load_balance_coeff_overrides_preset_default(self):
-        """Explicit user load_balance_coeff survives Llama4 preset resolution."""
-        config = parse_autoep_config({
-            "enabled": True,
-            "preset_model": "llama4",
-            "load_balance_coeff": 0.02,
-        })
-
-        resolved = resolve_autoep_config_defaults(config, config.preset_model)
-
-        assert resolved.load_balance_coeff == pytest.approx(0.02)
+    @pytest.mark.parametrize("enabled", [True, False])
+    @pytest.mark.parametrize("value", _UNSUPPORTED_LOAD_BALANCE_VALUES)
+    def test_explicit_load_balance_coeff_is_rejected_at_parse(self, enabled, value):
+        """Non-None load_balance_coeff is rejected before preset resolution."""
+        with pytest.raises(ValueError) as exc_info:
+            parse_autoep_config({
+                "enabled": enabled,
+                "load_balance_coeff": value,
+            })
+        _assert_load_balance_coeff_rejection_message(exc_info.value, value)
 
     @pytest.mark.parametrize("preset_model", ["deepseek_v2", "deepseek_v3"])
     def test_deepseek_preset_default_sets_load_balance_coeff_none(self, preset_model):
         """DeepSeek presets disable AutoEP expert_bias by default."""
         config = parse_autoep_config({"enabled": True, "preset_model": preset_model})
-        assert config.load_balance_coeff == pytest.approx(1e-3)
+        assert config.load_balance_coeff is None
 
         resolved = resolve_autoep_config_defaults(config, config.preset_model)
 
         assert resolved.load_balance_coeff is None
-        assert config.load_balance_coeff == pytest.approx(1e-3)
+        assert config.load_balance_coeff is None
 
     def test_deepseek_presets_mark_expert_bias_unsupported(self):
         assert PRESET_MODELS["deepseek_v2"].supports_expert_bias is False
@@ -121,7 +130,7 @@ class TestAutoEPConfig:
             "num_limited_groups": 1,
             "score_func": "sigmoid",
             "top_k": 2,
-            "load_balance_coeff": 0.01,
+            "load_balance_coeff": None,
             "routed_scaling_factor": 1.5,
             "expert_w1": "w1",
             "expert_w2": "w2",
@@ -147,7 +156,8 @@ class TestAutoEPConfig:
         assert config.num_limited_groups == 1
         assert config.score_func == "sigmoid"
         assert config.top_k == 2
-        assert config.load_balance_coeff == pytest.approx(0.01)
+        assert config.load_balance_coeff is None
+        assert config._load_balance_coeff_explicit is True
         assert config.routed_scaling_factor == 1.5
         assert config.expert_w1 == "w1"
         assert config.expert_w2 == "w2"
@@ -157,6 +167,35 @@ class TestAutoEPConfig:
         assert config.has_shared_experts is True
         assert config.shared_experts_pattern == "shared_expert"
         assert config.shared_experts_gate_pattern == "shared_expert_gate"
+
+    def test_absent_load_balance_coeff_disables_and_validates(self):
+        config = parse_autoep_config({"enabled": True})
+        assert config.load_balance_coeff is None
+        assert config._load_balance_coeff_explicit is False
+
+        validate_autoep_config(config, world_size=1, pp_size=1, tp_size=1, sp_size=1)
+
+    def test_explicit_null_load_balance_coeff_disables_and_validates(self):
+        config = parse_autoep_config({"enabled": True, "load_balance_coeff": None})
+        assert config.load_balance_coeff is None
+        assert config._load_balance_coeff_explicit is True
+
+        validate_autoep_config(config, world_size=1, pp_size=1, tp_size=1, sp_size=1)
+
+    @pytest.mark.parametrize("enabled", [True, False])
+    @pytest.mark.parametrize("value", [0.01, False, "0.01"])
+    def test_direct_construction_load_balance_coeff_rejected_by_validate(self, enabled, value):
+        config = AutoEPConfig(enabled=enabled, load_balance_coeff=value)
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_autoep_config(config, world_size=1, pp_size=1, tp_size=1, sp_size=1)
+        _assert_load_balance_coeff_rejection_message(exc_info.value, value)
+
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_direct_construction_null_load_balance_coeff_validates(self, enabled):
+        config = AutoEPConfig(enabled=enabled, load_balance_coeff=None)
+
+        validate_autoep_config(config, world_size=1, pp_size=1, tp_size=1, sp_size=1)
 
     def test_validate_ep_tp_mutual_exclusivity(self):
         """autotp_size>1 + sp_size>1 raises ValueError."""
@@ -871,23 +910,17 @@ class TestMoEDetection:
         assert replaced.expert_bias is None
         assert "expert_bias" not in dict(replaced.named_buffers())
 
-    def test_llama4_explicit_load_balance_coeff_keeps_expert_bias(self):
-        """Explicit load_balance_coeff for llama4 opts back into expert_bias."""
-        model = MockLlama4Transformer(num_layers=1, num_experts=4)
-        config = parse_autoep_config({
-            "enabled": True,
-            "autoep_size": 1,
-            "preset_model": "llama4",
-            "load_balance_coeff": 0.02,
-        })
-        auto_ep = AutoEP(model, config)
-        specs = auto_ep.ep_parser()
-        auto_ep.replace_moe_layer(specs[0], ep_size=1, ep_rank=0)
-
-        replaced = model.model.layers[0].feed_forward
-        assert replaced.load_balance_coeff == pytest.approx(0.02)
-        assert replaced.expert_bias is not None
-        assert "expert_bias" in dict(replaced.named_buffers())
+    @pytest.mark.parametrize("value", [1e-3, 0.02])
+    def test_llama4_explicit_load_balance_coeff_is_rejected_at_parse(self, value):
+        """Explicit load_balance_coeff is not an opt-in path for llama4."""
+        with pytest.raises(ValueError) as exc_info:
+            parse_autoep_config({
+                "enabled": True,
+                "autoep_size": 1,
+                "preset_model": "llama4",
+                "load_balance_coeff": value,
+            })
+        _assert_load_balance_coeff_rejection_message(exc_info.value, value)
 
     def test_auto_detect_llama4_layer_disables_expert_bias_by_default(self):
         """Auto-detected model_type='llama4' also applies the llama4 preset default."""
@@ -1039,21 +1072,17 @@ class TestMoEDetection:
 
     @pytest.mark.parametrize("preset_model", ["deepseek_v2", "deepseek_v3"])
     def test_deepseek_explicit_load_balance_coeff_rejected(self, preset_model):
-        """DeepSeek AutoEP fails explicitly instead of creating expert_bias."""
-        model = MockMoETransformer(num_layers=1, num_experts=4, moe_every_n=1)
-        config = parse_autoep_config({
-            "enabled": True,
-            "autoep_size": 1,
-            "preset_model": preset_model,
-            "top_k": 2,
-            "load_balance_coeff": 0.02,
-        })
-        auto_ep = AutoEP(model, config)
-        specs = auto_ep.ep_parser()
-        assert specs[0].supports_expert_bias is False
-
-        with pytest.raises(ValueError, match="load_balance_coeff/expert_bias"):
-            auto_ep.replace_moe_layer(specs[0], ep_size=1, ep_rank=0)
+        """DeepSeek AutoEP rejects load_balance_coeff before expert_bias exists."""
+        value = 0.02
+        with pytest.raises(ValueError) as exc_info:
+            parse_autoep_config({
+                "enabled": True,
+                "autoep_size": 1,
+                "preset_model": preset_model,
+                "top_k": 2,
+                "load_balance_coeff": value,
+            })
+        _assert_load_balance_coeff_rejection_message(exc_info.value, value)
 
     def test_deepseek_v3_nonzero_score_correction_bias_rejected(self):
         """DeepSeek-V3 expert correction bias remains unsupported for AutoEP parity."""


### PR DESCRIPTION
## Summary
- default AutoEP load balancing now resolves to disabled (`None`) for omitted and explicit `null` config values
- non-`None` `load_balance_coeff` values now fail during AutoEP config parsing/validation with a clear `ValueError` mentioning `expert_bias`
- default checkpoint/layer coverage now asserts `expert_bias` is not registered, and docs describe the key as reserved/unsupported

## Branches
- staging base cloned from `tohtana/add_autoep`: `tohtana/autoep-staging2` at `e463cdf6ff9aabb9c18e9c5156ce66bf67cb051b`
- head: `codex/disable-autoep-load-balance-expert-bias`

## Testing
- `timeout 240 conda run -n ds pytest tests/unit/moe/test_autoep_unit.py -v --forked -k 'load_balance or expert_bias or parse_autoep_config'` - 43 passed, 3 skipped, 87 deselected
- `timeout 360 conda run -n ds pytest tests/unit/moe/test_autoep_checkpoint.py -v --forked -k 'expert_bias or load_balance_coeff'` - 18 passed, 33 deselected
- `timeout 480 conda run -n ds pytest tests/unit/moe/test_autoep_unit.py -v --forked` - 126 passed, 7 skipped
- `timeout 300 conda run -n ds pre-commit run --files deepspeed/module_inject/auto_ep_config.py deepspeed/runtime/engine.py docs/_pages/config-json.md tests/unit/moe/test_autoep_checkpoint.py tests/unit/moe/test_autoep_unit.py` - passed

## Known Blocker
- `timeout 900 conda run -n ds pytest tests/unit/moe/test_autoep_grad_parity.py -v --forked` currently fails before parity assertions: AutoEP cannot detect MoE layers for `preset_model=\`mixtral\`` in the installed Transformers model structure.

Tracking: tohtana/dev_ds#88