### PR TITLE
Fix AutoEP PR 7938 review regressions

### DIFF
--- a/deepspeed/checkpoint/ds_to_universal.py
+++ b/deepspeed/checkpoint/ds_to_universal.py
@@ -502,8 +502,15 @@ def main(args):
         _merge_tp_slice_files(args, ds_checkpoint, slice_shapes, temp_dir)
 
         print('*** 2.5. Consolidating AutoEP expert files')
-        from .constants import AUTOEP_LAYERS_KEY, AUTOEP_LAYERS_KEY_LEGACY, EXPERT_PARAMETER_PATTERNS
-        from .autoep_universal import consolidate_autoep_expert_files, consolidate_autoep_optimizer_states
+        from deepspeed.checkpoint.constants import (
+            AUTOEP_LAYERS_KEY,
+            AUTOEP_LAYERS_KEY_LEGACY,
+            EXPERT_PARAMETER_PATTERNS,
+        )
+        from deepspeed.checkpoint.autoep_universal import (
+            consolidate_autoep_expert_files,
+            consolidate_autoep_optimizer_states,
+        )
 
         # Load AutoEP metadata from main checkpoint
         main_sd = torch.load(ds_checkpoint.mp_rank_files[0], map_location=torch.device('cpu'), weights_only=False)

--- a/deepspeed/module_inject/auto_ep.py
+++ b/deepspeed/module_inject/auto_ep.py
@@ -504,6 +504,8 @@ class AutoEP:
         """Return whether empty detection should fail for the selected preset."""
         if self.config.preset_model is not None:
             return True
+        if self.config.moe_layer_pattern is not None:
+            return True
         if self.model_config is None:
             return False
         model_type = getattr(self.model_config, 'model_type', None)
@@ -513,6 +515,8 @@ class AutoEP:
         model_type = getattr(self.model_config, 'model_type', None)
         if self.config.preset_model is not None:
             source = f"preset_model='{self.config.preset_model}'"
+        elif self.config.moe_layer_pattern is not None:
+            source = f"moe_layer_pattern='{self.config.moe_layer_pattern}'"
         else:
             source = f"model_type='{model_type}'"
 

--- a/deepspeed/runtime/base_optimizer.py
+++ b/deepspeed/runtime/base_optimizer.py
@@ -18,6 +18,21 @@ class DeepSpeedOptimizer(object):
     pass
 
 
+def _get_universal_checkpoint_ep_info() -> tuple[int, int]:
+    # Universal checkpoints use EP slicing only when an expert group exists.
+    try:
+        from deepspeed.utils import groups
+        expert_groups = groups._get_expert_parallel_group_dict()
+        if not expert_groups:
+            return 0, 1
+        max_ep_name = groups._get_max_expert_size_name()
+        if max_ep_name not in expert_groups:
+            return 0, 1
+        return groups._get_expert_parallel_rank(max_ep_name), groups._get_expert_parallel_world_size(max_ep_name)
+    except (RuntimeError, AttributeError, KeyError):
+        return 0, 1
+
+
 class BackwardHookStateManager:
     """Manages backward pass state for ZeRO optimizers.
 
@@ -314,15 +329,7 @@ class ZeROOptimizer(DeepSpeedOptimizer):
             tp_world_size = self.mpu.get_slice_parallel_world_size() if hasattr(self.mpu, "get_slice_parallel_world_size") \
                 else self.mpu.get_tensor_model_parallel_world_size()
 
-        # Obtain EP rank/size for universal checkpoint expert parameter slicing.
-        # Guarded for non-MoE models where expert groups don't exist.
-        try:
-            from deepspeed.utils import groups
-            max_ep_name = groups._get_max_expert_size_name()
-            ep_rank = groups._get_expert_parallel_rank(max_ep_name)
-            ep_size = groups._get_expert_parallel_world_size(max_ep_name)
-        except (RuntimeError, AttributeError, KeyError):
-            ep_rank, ep_size = 0, 1
+        ep_rank, ep_size = _get_universal_checkpoint_ep_info()
 
         for i, (param_group,
                 loaded_param_group) in enumerate(zip(self.optimizer.param_groups, optim_sd['param_groups'])):

--- a/tests/unit/moe/test_autoep_checkpoint.py
+++ b/tests/unit/moe/test_autoep_checkpoint.py
@@ -4,6 +4,8 @@
 # DeepSpeed Team
 """Tests for AutoEP checkpointing (save/load, metadata, universal stubs)."""
 
+import ast
+import inspect
 import os
 import copy
 import pytest
@@ -747,6 +749,25 @@ class TestAutoEPCheckpoint2GPU(DistributedTest):
 
 class TestUniversalConvert(DistributedTest):
     world_size = 1
+
+    def test_universal_converter_main_uses_absolute_autoep_imports(self):
+        """Direct script execution of ds_to_universal.py must not hit package-relative imports."""
+        import deepspeed.checkpoint.ds_to_universal as ds_to_universal
+
+        main_tree = ast.parse(inspect.getsource(ds_to_universal.main))
+        relative_imports = [
+            node.module for node in ast.walk(main_tree) if isinstance(node, ast.ImportFrom) and node.level
+        ]
+
+        assert relative_imports == []
+
+    def test_load_hp_checkpoint_state_non_expert_groups_default_to_data_parallel(self, monkeypatch):
+        from deepspeed.runtime import base_optimizer
+        from deepspeed.utils import groups
+
+        monkeypatch.setattr(groups, "_EXPERT_PARALLEL_GROUP", {})
+
+        assert base_optimizer._get_universal_checkpoint_ep_info() == (0, 1)
 
     def test_universal_convert_autoep_metadata_written(self, tmpdir):
         """Run ds_to_universal on AutoEP checkpoint; verify universal_checkpoint_info."""

--- a/tests/unit/moe/test_autoep_unit.py
+++ b/tests/unit/moe/test_autoep_unit.py
@@ -992,6 +992,26 @@ class TestMoEDetection:
         assert "no MoE layers detected" in message
         assert "moe_layer_pattern" in message
 
+    def test_explicit_custom_pattern_without_matching_moe_layers_fails_actionably(self):
+        """A custom pattern typo should not silently leave the model unreplaced."""
+        model = MockMoETransformer(num_layers=1, moe_every_n=1)
+        model.config.model_type = "custom"
+        config = AutoEPConfig(
+            enabled=True,
+            autoep_size=1,
+            moe_layer_pattern=r"model\.layers\.\d+\.wrong",
+            router_pattern="gate",
+            expert_pattern="experts",
+        )
+
+        with pytest.raises(ValueError) as exc:
+            AutoEP(model, config).ep_parser()
+
+        message = str(exc.value)
+        assert "moe_layer_pattern='model\\.layers\\.\\d+\\.wrong'" in message
+        assert "custom" in message
+        assert "no MoE layers detected" in message
+
     def test_detect_fused_3d_storage(self):
         """Correctly identifies fused_3d expert storage."""
         model = MockMoETransformer(num_layers=2, moe_every_n=1)


### PR DESCRIPTION
## Summary

- Use absolute AutoEP imports in `ds_to_universal.py` so the documented direct-script converter path keeps working.
- Default universal checkpoint optimizer EP slicing to `ep_rank=0, ep_size=1` when no expert parallel group exists.
- Treat an explicit custom `moe_layer_pattern` as selected detection, so pattern typos fail with the existing actionable no-layers error.

## Validation

- `python -m py_compile deepspeed/checkpoint/ds_to_universal.py deepspeed/runtime/base_optimizer.py deepspeed/module_inject/auto_ep.py tests/unit/moe/test_autoep_unit.py tests/unit/moe/test_autoep_checkpoint.py` - passed
- `pytest -q tests/unit/moe/test_autoep_unit.py -k "custom or no_moe or preset"` - 30 passed, 1 skipped, 144 deselected
- `pytest -q tests/unit/moe/test_autoep_checkpoint.py -k "universal or load_hp or non_expert"` - first run exposed missing `ninja` for FusedAdam JIT; after `python -m pip install ninja`, rerun passed with 14 passed, 39 deselected
- `git diff --check` - passed
- `pre-commit run --files deepspeed/checkpoint/ds_to_universal.py deepspeed/module_inject/auto_ep.py deepspeed/runtime/base_optimizer.py tests/unit/moe/test_autoep_checkpoint.py tests/unit/moe/test_autoep_unit.py` - passed
- `git verify-commit HEAD` - passed