### PR TITLE
Fix AutoEP PR #7938 review follow-ups

### DIFF
--- a/deepspeed/module_inject/auto_ep_config.py
+++ b/deepspeed/module_inject/auto_ep_config.py
@@ -103,10 +103,10 @@ def validate_autoep_config(
     if not config.enabled:
         return
 
-    # TP + SP mutual exclusivity
-    if tp_size > 1 and sp_size > 1:
-        raise ValueError(f"AutoEP does not support simultaneous TP (autotp_size={tp_size}) "
-                         f"and SP (sequence_parallel_size={sp_size}). Use one or the other.")
+    if tp_size > 1:
+        raise ValueError("AutoEP does not currently support AutoTP "
+                         f"(tensor_parallel.autotp_size={tp_size}). Disable AutoTP for this run; "
+                         "AutoEP+AutoTP support is planned as follow-up work.")
 
     # ep_size must divide the stage size (world_size / pp_size)
     stage_size = world_size // pp_size

--- a/deepspeed/module_inject/auto_ep_preset_adapters.py
+++ b/deepspeed/module_inject/auto_ep_preset_adapters.py
@@ -2,7 +2,12 @@
 # DeepSpeed Team
 """Compatibility shim for AutoEP preset adapter APIs."""
 
-from deepspeed.module_inject.auto_ep_presets.base import AutoEPPresetAdapter, ForwardContract, GroupRoutingConfig
+from deepspeed.module_inject.auto_ep_presets.base import (
+    AutoEPPresetAdapter,
+    ForwardContract,
+    GroupRoutingConfig,
+    TransformersTopLevelRouterLogitsAdapter,
+)
 from deepspeed.module_inject.auto_ep_presets.deepseek_v2 import DeepSeekV2PresetAdapter
 from deepspeed.module_inject.auto_ep_presets.deepseek_v3 import DeepSeekV3PresetAdapter
 from deepspeed.module_inject.auto_ep_presets.llama4 import Llama4PresetAdapter
@@ -17,5 +22,6 @@ __all__ = [
     "GroupRoutingConfig",
     "Llama4PresetAdapter",
     "Qwen35MoePresetAdapter",
+    "TransformersTopLevelRouterLogitsAdapter",
     "get_preset_adapter",
 ]

--- a/deepspeed/module_inject/auto_ep_presets/base.py
+++ b/deepspeed/module_inject/auto_ep_presets/base.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Callable, Literal, NoReturn
 
 import torch.nn as nn
@@ -258,3 +258,85 @@ class AutoEPPresetAdapter:
         remove_output_capture_hooks: Callable[[nn.Module], int],
     ) -> None:
         return
+
+
+class TransformersTopLevelRouterLogitsAdapter(AutoEPPresetAdapter):
+    """Retarget Transformers model-level router-logit recorders to AutoEP."""
+
+    def __init__(
+        self,
+        *,
+        display_name: str,
+        hf_model_types: tuple[str, ...],
+        class_name_fragments: tuple[str, ...],
+    ) -> None:
+        self.display_name = display_name
+        self.hf_model_types = hf_model_types
+        self.class_name_fragments = class_name_fragments
+
+    def adjust_forward_contract(self, contract: ForwardContract) -> ForwardContract:
+        # Mixtral/Qwen3/Qwen2 capture raw router logits through Transformers'
+        # model-level OutputRecorder hooks. AutoEP keeps the MoE block tensor
+        # return contract intact and retargets the recorder to router.gate.
+        return replace(
+            contract,
+            return_router_logits=False,
+            capture_target="router",
+            capture_index=0,
+            router_logits_capture_mode="raw",
+        )
+
+    def retarget_transformers_output_recorders(
+        self,
+        model: nn.Module,
+        spec: MoELayerSpec,
+        replacement: nn.Module,
+        retargeted_keys: set[str],
+        remove_output_capture_hooks: Callable[[nn.Module], int],
+    ) -> None:
+        recorder_key = f"{spec.model_family}:{replacement.__class__.__module__}.{replacement.__class__.__qualname__}"
+        if recorder_key in retargeted_keys:
+            return
+        retargeted_keys.add(recorder_key)
+
+        try:
+            from transformers.utils.output_capturing import _CAN_RECORD_REGISTRY, OutputRecorder
+        except Exception:
+            return
+
+        router_gate = getattr(getattr(replacement, "router", None), "gate", None)
+        if router_gate is None:
+            return
+
+        retargeted = 0
+        for module in model.modules():
+            module_config = getattr(module, "config", None)
+            model_type = getattr(module_config, "model_type", None)
+            class_name = module.__class__.__name__
+            if model_type not in self.hf_model_types and not any(fragment in class_name
+                                                                 for fragment in self.class_name_fragments):
+                continue
+
+            registry_key = str(module.__class__)
+            record_outputs = getattr(module, "_can_record_outputs", None)
+            registry_outputs = _CAN_RECORD_REGISTRY.get(registry_key)
+            base_outputs = record_outputs if isinstance(record_outputs, dict) else registry_outputs
+            if not isinstance(base_outputs, dict) or "router_logits" not in base_outputs:
+                continue
+
+            retargeted_outputs = dict(base_outputs)
+            retargeted_outputs["router_logits"] = OutputRecorder(router_gate.__class__,
+                                                                 index=0,
+                                                                 layer_name="router.gate")
+            module._can_record_outputs = retargeted_outputs
+            _CAN_RECORD_REGISTRY[registry_key] = retargeted_outputs
+
+            if getattr(module, "_output_capturing_hooks_installed", False):
+                remove_output_capture_hooks(module)
+            module._output_capturing_hooks_installed = False
+            retargeted += 1
+
+        if retargeted == 0:
+            from deepspeed.utils import logger
+            logger.warning(f"AutoEP: {self.display_name} conversion did not find a HF output-capture registry "
+                           "entry for router_logits.")

--- a/deepspeed/module_inject/auto_ep_presets/base.py
+++ b/deepspeed/module_inject/auto_ep_presets/base.py
@@ -260,6 +260,111 @@ class AutoEPPresetAdapter:
         return
 
 
+_MISSING_REGISTRY_ENTRY = object()
+
+
+def _restore_transformers_output_capture_registry(
+    registry: dict[str, Any],
+    original_entries: dict[str, object],
+) -> None:
+    for registry_key, original_entry in original_entries.items():
+        if original_entry is _MISSING_REGISTRY_ENTRY:
+            registry.pop(registry_key, None)
+        else:
+            registry[registry_key] = original_entry
+
+
+def _install_instance_transformers_output_recorders(
+    model: nn.Module,
+    registry_entries: dict[str, dict[str, Any]],
+    output_capturing: Any,
+    remove_output_capture_hooks: Callable[[nn.Module], int],
+) -> bool:
+    maybe_install_capturing_hooks = getattr(output_capturing, "maybe_install_capturing_hooks", None)
+    registry = getattr(output_capturing, "_CAN_RECORD_REGISTRY", None)
+    if not callable(maybe_install_capturing_hooks) or not isinstance(registry, dict):
+        return False
+
+    remove_output_capture_hooks(model)
+    for module in model.modules():
+        if hasattr(module, "_output_capturing_hooks_installed"):
+            module._output_capturing_hooks_installed = False
+    model._output_capturing_hooks_installed = False
+
+    original_entries = {
+        registry_key: registry.get(registry_key, _MISSING_REGISTRY_ENTRY)
+        for registry_key in registry_entries
+    }
+    try:
+        registry.update(registry_entries)
+        maybe_install_capturing_hooks(model)
+    finally:
+        _restore_transformers_output_capture_registry(registry, original_entries)
+    return True
+
+
+def _retarget_transformers_output_recorders_for_modules(
+    *,
+    model: nn.Module,
+    display_name: str,
+    recorder_key: str,
+    retargeted_keys: set[str],
+    remove_output_capture_hooks: Callable[[nn.Module], int],
+    module_matches: Callable[[nn.Module], bool],
+    make_output_recorder: Callable[[Any], Any],
+) -> int:
+    try:
+        from transformers.utils import output_capturing
+    except Exception:
+        return 0
+
+    registry = getattr(output_capturing, "_CAN_RECORD_REGISTRY", None)
+    if not isinstance(registry, dict):
+        return 0
+
+    registry_entries: dict[str, dict[str, Any]] = {}
+    retargeted = 0
+    for module in model.modules():
+        if not module_matches(module):
+            continue
+
+        registry_key = str(module.__class__)
+        record_outputs = getattr(module, "_can_record_outputs", None)
+        registry_outputs = registry.get(registry_key)
+        base_outputs = record_outputs if isinstance(record_outputs, dict) else registry_outputs
+        if not isinstance(base_outputs, dict) or "router_logits" not in base_outputs:
+            continue
+
+        retargeted_outputs = dict(base_outputs)
+        retargeted_outputs["router_logits"] = make_output_recorder(output_capturing.OutputRecorder)
+        module._can_record_outputs = retargeted_outputs
+        registry_entries[registry_key] = retargeted_outputs
+        retargeted += 1
+
+    if retargeted == 0:
+        from deepspeed.utils import logger
+        logger.warning(f"AutoEP: {display_name} conversion did not find a HF output-capture registry "
+                       "entry for router_logits.")
+        return 0
+
+    if _install_instance_transformers_output_recorders(
+            model,
+            registry_entries,
+            output_capturing,
+            remove_output_capture_hooks,
+    ):
+        return retargeted
+
+    if recorder_key in retargeted_keys:
+        return retargeted
+    retargeted_keys.add(recorder_key)
+    registry.update(registry_entries)
+    if getattr(model, "_output_capturing_hooks_installed", False):
+        remove_output_capture_hooks(model)
+    model._output_capturing_hooks_installed = False
+    return retargeted
+
+
 class TransformersTopLevelRouterLogitsAdapter(AutoEPPresetAdapter):
     """Retarget Transformers model-level router-logit recorders to AutoEP."""
 
@@ -295,48 +400,25 @@ class TransformersTopLevelRouterLogitsAdapter(AutoEPPresetAdapter):
         remove_output_capture_hooks: Callable[[nn.Module], int],
     ) -> None:
         recorder_key = f"{spec.model_family}:{replacement.__class__.__module__}.{replacement.__class__.__qualname__}"
-        if recorder_key in retargeted_keys:
-            return
-        retargeted_keys.add(recorder_key)
-
-        try:
-            from transformers.utils.output_capturing import _CAN_RECORD_REGISTRY, OutputRecorder
-        except Exception:
-            return
 
         router_gate = getattr(getattr(replacement, "router", None), "gate", None)
         if router_gate is None:
             return
 
-        retargeted = 0
-        for module in model.modules():
+        def module_matches(module: nn.Module) -> bool:
             module_config = getattr(module, "config", None)
             model_type = getattr(module_config, "model_type", None)
             class_name = module.__class__.__name__
-            if model_type not in self.hf_model_types and not any(fragment in class_name
-                                                                 for fragment in self.class_name_fragments):
-                continue
+            return (model_type in self.hf_model_types
+                    or any(fragment in class_name for fragment in self.class_name_fragments))
 
-            registry_key = str(module.__class__)
-            record_outputs = getattr(module, "_can_record_outputs", None)
-            registry_outputs = _CAN_RECORD_REGISTRY.get(registry_key)
-            base_outputs = record_outputs if isinstance(record_outputs, dict) else registry_outputs
-            if not isinstance(base_outputs, dict) or "router_logits" not in base_outputs:
-                continue
-
-            retargeted_outputs = dict(base_outputs)
-            retargeted_outputs["router_logits"] = OutputRecorder(router_gate.__class__,
-                                                                 index=0,
-                                                                 layer_name="router.gate")
-            module._can_record_outputs = retargeted_outputs
-            _CAN_RECORD_REGISTRY[registry_key] = retargeted_outputs
-
-            if getattr(module, "_output_capturing_hooks_installed", False):
-                remove_output_capture_hooks(module)
-            module._output_capturing_hooks_installed = False
-            retargeted += 1
-
-        if retargeted == 0:
-            from deepspeed.utils import logger
-            logger.warning(f"AutoEP: {self.display_name} conversion did not find a HF output-capture registry "
-                           "entry for router_logits.")
+        _retarget_transformers_output_recorders_for_modules(
+            model=model,
+            display_name=self.display_name,
+            recorder_key=recorder_key,
+            retargeted_keys=retargeted_keys,
+            remove_output_capture_hooks=remove_output_capture_hooks,
+            module_matches=module_matches,
+            make_output_recorder=lambda OutputRecorder: OutputRecorder(
+                router_gate.__class__, index=0, layer_name="router.gate"),
+        )

--- a/deepspeed/module_inject/auto_ep_presets/mixtral.py
+++ b/deepspeed/module_inject/auto_ep_presets/mixtral.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from deepspeed.module_inject.auto_ep_presets.base import MoEModelPreset
+from deepspeed.module_inject.auto_ep_presets.base import MoEModelPreset, TransformersTopLevelRouterLogitsAdapter
 
 PRESET_NAME = "mixtral"
 
@@ -22,6 +22,16 @@ PRESET = MoEModelPreset(
     score_apply="post",
     route_norm=True,
     gate_bias=False,
+    preset_adapter="mixtral",
     hf_model_types=("mixtral", ),
     min_transformers_version="5.0.0",
 )
+
+PRESET_ADAPTERS = {
+    "mixtral":
+    TransformersTopLevelRouterLogitsAdapter(
+        display_name="Mixtral",
+        hf_model_types=("mixtral", ),
+        class_name_fragments=("Mixtral", ),
+    ),
+}

--- a/deepspeed/module_inject/auto_ep_presets/qwen3_5_moe.py
+++ b/deepspeed/module_inject/auto_ep_presets/qwen3_5_moe.py
@@ -14,8 +14,8 @@ from deepspeed.module_inject.auto_ep_presets.base import (
     ForwardContract,
     MoELayerSpec,
     MoEModelPreset,
+    _retarget_transformers_output_recorders_for_modules,
 )
-from deepspeed.utils import logger
 
 PRESET_NAME = "qwen3_5_moe"
 
@@ -72,51 +72,24 @@ class Qwen35MoePresetAdapter(AutoEPPresetAdapter):
         remove_output_capture_hooks: Callable[[nn.Module], int],
     ) -> None:
         recorder_key = f"{spec.model_family}:{replacement.__class__.__module__}.{replacement.__class__.__qualname__}"
-        if recorder_key in retargeted_keys:
-            return
-        retargeted_keys.add(recorder_key)
 
-        try:
-            from transformers.utils.output_capturing import _CAN_RECORD_REGISTRY, OutputRecorder
-        except Exception as exc:
-            logger.warning(f"AutoEP: could not retarget Qwen3.5 router-logit output capture: {exc}")
-            return
-
-        retargeted = 0
         replacement_cls = replacement.__class__
-        for module in model.modules():
+
+        def module_matches(module: nn.Module) -> bool:
             module_config = getattr(module, "config", None)
             model_type = getattr(module_config, "model_type", None)
             class_name = module.__class__.__name__
-            if model_type != "qwen3_5_moe_text" and "Qwen3_5Moe" not in class_name:
-                continue
+            return model_type == "qwen3_5_moe_text" or "Qwen3_5Moe" in class_name
 
-            registry_key = str(module.__class__)
-            record_outputs = getattr(module, "_can_record_outputs", None)
-            registry_outputs = _CAN_RECORD_REGISTRY.get(registry_key)
-            base_outputs = record_outputs if isinstance(record_outputs, dict) else registry_outputs
-            if not isinstance(base_outputs, dict) or "router_logits" not in base_outputs:
-                continue
-
-            retargeted_outputs = dict(base_outputs)
-            retargeted_outputs["router_logits"] = OutputRecorder(replacement_cls, index=1)
-            module._can_record_outputs = retargeted_outputs
-            _CAN_RECORD_REGISTRY[registry_key] = retargeted_outputs
-
-            if getattr(module, "_output_capturing_hooks_installed", False):
-                removed = remove_output_capture_hooks(module)
-                if removed:
-                    logger.debug(f"AutoEP: removed {removed} stale HF output-capturing hook(s) "
-                                 f"from {class_name}.")
-            module._output_capturing_hooks_installed = False
-            retargeted += 1
-
-        if retargeted:
-            logger.info("AutoEP: retargeted Qwen3.5 HF router-logit output capture to record "
-                        f"{replacement_cls.__name__} output index 1 on {retargeted} module(s).")
-        else:
-            logger.warning("AutoEP: Qwen3.5 AutoEP conversion did not find a HF output-capture registry "
-                           "entry for router_logits.")
+        _retarget_transformers_output_recorders_for_modules(
+            model=model,
+            display_name="Qwen3.5 AutoEP",
+            recorder_key=recorder_key,
+            retargeted_keys=retargeted_keys,
+            remove_output_capture_hooks=remove_output_capture_hooks,
+            module_matches=module_matches,
+            make_output_recorder=lambda OutputRecorder: OutputRecorder(replacement_cls, index=1),
+        )
 
 
 PRESET_ADAPTERS = {

--- a/deepspeed/module_inject/auto_ep_presets/qwen3_moe.py
+++ b/deepspeed/module_inject/auto_ep_presets/qwen3_moe.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from deepspeed.module_inject.auto_ep_presets.base import MoEModelPreset
+from deepspeed.module_inject.auto_ep_presets.base import MoEModelPreset, TransformersTopLevelRouterLogitsAdapter
 
 PRESET_NAME = "qwen3_moe"
 
@@ -25,8 +25,18 @@ PRESET = MoEModelPreset(
     has_shared_experts=True,
     shared_experts_pattern="shared_expert",
     shared_experts_gate_pattern="shared_expert_gate",
+    preset_adapter="qwen3_moe",
     hf_model_types=("qwen3_moe", "qwen2_moe"),
     min_transformers_version="5.0.0",
     docs_support_notes=("Also covers Qwen2-MoE when the installed Transformers build uses the "
                         "validated fused expert layout."),
 )
+
+PRESET_ADAPTERS = {
+    "qwen3_moe":
+    TransformersTopLevelRouterLogitsAdapter(
+        display_name="Qwen3-MoE/Qwen2-MoE",
+        hf_model_types=("qwen3_moe", "qwen2_moe"),
+        class_name_fragments=("Qwen3Moe", "Qwen2Moe"),
+    ),
+}

--- a/deepspeed/moe/sharded_moe.py
+++ b/deepspeed/moe/sharded_moe.py
@@ -109,6 +109,12 @@ class _AllToAll(torch.autograd.Function):
         return (None, _AllToAll.apply(ctx.group, *grad_output))
 
 
+def _is_multi_rank_ep_group(ep_group: Union[dist.ProcessGroup, None]) -> bool:
+    if ep_group is None:
+        return False
+    return dist.get_world_size(group=ep_group) > 1
+
+
 # einsum rewrites are on par or more performant
 # switch can be bubbled up in future
 USE_EINSUM = True
@@ -215,7 +221,7 @@ def top1gating(logits: Tensor,
     if not drop_tokens:
         new_capacity = torch.max(exp_counts).to(logits.device)
         # Communicate across expert processes to pick the maximum capacity.
-        if ep_group is not None:
+        if _is_multi_rank_ep_group(ep_group):
             dist.all_reduce(new_capacity, op=dist.ReduceOp.MAX, group=ep_group)
         if groups._get_expert_model_parallel_world_size() == 1:
             # If the non-expert is tensor-parallel, we need to pad the capacity to 'tp'.
@@ -335,7 +341,7 @@ def top2gating(logits: Tensor,
     else:
         # Do not drop tokens - set capacity according to current expert assignments
         new_capacity = torch.max(exp_counts)
-        if ep_group is not None:
+        if _is_multi_rank_ep_group(ep_group):
             dist.all_reduce(new_capacity, op=dist.ReduceOp.MAX, group=ep_group)
         if groups._get_expert_model_parallel_world_size() == 1:
             # If the non-expert is tensor-parallel, we need to pad the capacity to 'tp'.
@@ -421,7 +427,7 @@ def topkgating(
     else:
         # Do not drop tokens - set capacity according to current expert assignments
         new_capacity = torch.max(exp_counts)
-        if ep_group is not None:
+        if _is_multi_rank_ep_group(ep_group):
             dist.all_reduce(new_capacity, op=dist.ReduceOp.MAX, group=ep_group)
         if groups._get_expert_model_parallel_world_size() == 1:
             # If the non-expert is tensor-parallel, we need to pad the capacity to 'tp'.
@@ -628,7 +634,8 @@ class MOELayer(Base):
             # an allgather to ensure correctness,
             dispatched_input = drop_tokens(dispatched_input, dim=1)
 
-        dispatched_input = _AllToAll.apply(self.ep_group, dispatched_input)
+        if self.ep_size > 1:
+            dispatched_input = _AllToAll.apply(self.ep_group, dispatched_input)
 
         if self.wall_clock_breakdown:
             self.timers(FIRST_ALLTOALL_TIMER).stop()
@@ -654,7 +661,8 @@ class MOELayer(Base):
         if self.wall_clock_breakdown:
             self.timers(SECOND_ALLTOALL_TIMER).start()
 
-        expert_output = _AllToAll.apply(self.ep_group, expert_output)
+        if self.ep_size > 1:
+            expert_output = _AllToAll.apply(self.ep_group, expert_output)
 
         if self.wall_clock_breakdown:
             self.timers(SECOND_ALLTOALL_TIMER).stop()

--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -1070,7 +1070,7 @@ Use a built-in preset but override specific naming/weight fields for a fine-tune
 
 **Constraints:**
 - `autoep_size` must divide `num_experts` for all detected MoE layers
-- AutoTP (`autotp_size > 1`) and sequence parallelism (`sp_size > 1`) cannot both be active simultaneously
+- AutoEP currently cannot be combined with AutoTP (`tensor_parallel.autotp_size > 1`); support is planned as follow-up work
 - ZeRO Stage 3 is not supported with AutoEP (assertion will fire)
 
 ### Logging

--- a/docs/code-docs/source/moe.rst
+++ b/docs/code-docs/source/moe.rst
@@ -84,7 +84,8 @@ Transformers build that exposes the matching config/model classes,
 - ``autoep_size`` must divide ``num_experts`` for all detected MoE layers.
 - ``autoep_size=1`` is valid: all experts remain local (no AllToAll), useful
   for functional testing on a single GPU.
-- AutoTP and sequence parallelism cannot both be active simultaneously.
+- AutoEP currently cannot be combined with AutoTP
+  (``tensor_parallel.autotp_size > 1``); support is planned as follow-up work.
 - Checkpoint save/load requires matching ``autoep_size``.
   To change ``autoep_size`` across runs for the same AutoEP-detected model
   topology, convert the checkpoint to Universal Checkpoint format and load it

--- a/tests/unit/moe/test_autoep_unit.py
+++ b/tests/unit/moe/test_autoep_unit.py
@@ -850,6 +850,16 @@ class MockRecordingRouter(nn.Linear):
     _can_record_outputs = {"router_logits": {"index": 1, "layer_name": "router"}}
 
 
+def _install_fake_output_capturing(monkeypatch, fake_output_capturing):
+    fake_transformers = types.ModuleType("transformers")
+    fake_transformers_utils = types.ModuleType("transformers.utils")
+    fake_transformers.utils = fake_transformers_utils
+    fake_transformers_utils.output_capturing = fake_output_capturing
+    monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+    monkeypatch.setitem(sys.modules, "transformers.utils", fake_transformers_utils)
+    monkeypatch.setitem(sys.modules, "transformers.utils.output_capturing", fake_output_capturing)
+
+
 class MockDenseBlock(nn.Module):
     """Dense FFN block (should be skipped by detection)."""
 
@@ -1456,7 +1466,7 @@ class TestMoEDetection:
         fake_output_capturing = types.ModuleType("transformers.utils.output_capturing")
         fake_output_capturing.OutputRecorder = FakeOutputRecorder
         fake_output_capturing._CAN_RECORD_REGISTRY = {}
-        monkeypatch.setitem(sys.modules, "transformers.utils.output_capturing", fake_output_capturing)
+        _install_fake_output_capturing(monkeypatch, fake_output_capturing)
 
         model = MockMoETransformer(num_layers=1, num_experts=4, moe_every_n=1)
         model.config.model_type = model_type
@@ -1482,6 +1492,56 @@ class TestMoEDetection:
         assert recorder.layer_name == "router.gate"
         output = replacement(torch.randn(2, 5, 64))
         assert isinstance(output, torch.Tensor)
+
+    def test_top_level_hf_router_capture_restores_registry_after_hook_install(self, monkeypatch):
+        """Real HF hook installation uses a temporary registry override for the converted instance."""
+
+        class FakeOutputRecorder:
+
+            def __init__(self, target_class, index=0, layer_name=None, class_name=None):
+                self.target_class = target_class
+                self.index = index
+                self.layer_name = layer_name
+                self.class_name = class_name
+
+        fake_output_capturing = types.ModuleType("transformers.utils.output_capturing")
+        fake_output_capturing.OutputRecorder = FakeOutputRecorder
+        fake_output_capturing._CAN_RECORD_REGISTRY = {}
+        installed_recorders = []
+
+        def maybe_install_capturing_hooks(hook_model):
+            recorder = fake_output_capturing._CAN_RECORD_REGISTRY[str(hook_model.__class__)]["router_logits"]
+            installed_recorders.append(recorder)
+            hook_model._output_capturing_hooks_installed = True
+
+        fake_output_capturing.maybe_install_capturing_hooks = maybe_install_capturing_hooks
+        _install_fake_output_capturing(monkeypatch, fake_output_capturing)
+
+        model = MockMoETransformer(num_layers=1, num_experts=4, moe_every_n=1)
+        model.config.model_type = "mixtral"
+        model.config.num_experts = 4
+        model.model.layers[0].mlp.gate = MockRecordingRouter(64, 4, bias=False)
+        original_outputs = {"router_logits": FakeOutputRecorder(MockRecordingRouter, index=0)}
+        registry_key = str(model.__class__)
+        fake_output_capturing._CAN_RECORD_REGISTRY[registry_key] = original_outputs
+        model._can_record_outputs = original_outputs
+        config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+            "preset_model": "mixtral",
+            "use_grouped_mm": False,
+        })
+        auto_ep = AutoEP(model, config)
+        specs = auto_ep.ep_parser()
+
+        auto_ep.replace_moe_layer(specs[0], ep_size=1, ep_rank=0)
+
+        replacement = model.model.layers[0].mlp
+        assert isinstance(replacement, AutoEPMoELayer)
+        assert fake_output_capturing._CAN_RECORD_REGISTRY[registry_key] is original_outputs
+        assert installed_recorders
+        assert installed_recorders[0].target_class is replacement.router.gate.__class__
+        assert model._can_record_outputs["router_logits"].target_class is replacement.router.gate.__class__
 
     def test_replace_moe_layer_works(self):
         """replace_moe_layer creates AutoEPMoELayer replacement."""

--- a/tests/unit/moe/test_autoep_unit.py
+++ b/tests/unit/moe/test_autoep_unit.py
@@ -7,6 +7,8 @@
 import ast
 import copy
 import re
+import sys
+import types
 from dataclasses import replace
 from pathlib import Path
 
@@ -220,11 +222,11 @@ class TestAutoEPConfig:
 
         validate_autoep_config(config, world_size=1, pp_size=1, tp_size=1, sp_size=1)
 
-    def test_validate_ep_tp_mutual_exclusivity(self):
-        """autotp_size>1 + sp_size>1 raises ValueError."""
+    def test_validate_ep_rejects_autotp(self):
+        """AutoEP + AutoTP is rejected before replacement/partitioning."""
         config = AutoEPConfig(enabled=True, autoep_size=2)
-        with pytest.raises(ValueError, match="simultaneous TP.*and SP"):
-            validate_autoep_config(config, world_size=8, pp_size=1, tp_size=2, sp_size=2)
+        with pytest.raises(ValueError, match="AutoEP.*AutoTP.*autotp_size=2"):
+            validate_autoep_config(config, world_size=8, pp_size=1, tp_size=2, sp_size=1)
 
     def test_validate_ep_size_divides_stage(self):
         """ep_size must divide world_size / pp_size."""
@@ -1409,6 +1411,78 @@ class TestMoEDetection:
         assert specs[0].router_logits_capture_index == 1
         assert specs[0].router_logits_capture_mode == "post_score"
 
+    @pytest.mark.parametrize(("preset_model", "model_type"), [
+        ("mixtral", "mixtral"),
+        ("qwen3_moe", "qwen3_moe"),
+        ("qwen3_moe", "qwen2_moe"),
+    ])
+    def test_top_level_hf_router_capture_contract_records_raw_logits_without_tuple_return(
+            self, preset_model, model_type):
+        """Mixtral/Qwen3/Qwen2 top-level OutputRecorder capture stays raw and tensor-returning."""
+        model = MockMoETransformer(num_layers=1, num_experts=4, moe_every_n=1)
+        model.config.model_type = model_type
+        model.config.num_experts = 4
+        model.model.layers[0].mlp.gate = MockRecordingRouter(64, 4, bias=False)
+        config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+            "preset_model": preset_model,
+        })
+
+        specs = AutoEP(model, config).ep_parser()
+
+        assert len(specs) == 1
+        assert specs[0].return_router_logits is False
+        assert specs[0].router_logits_capture_target == "router"
+        assert specs[0].router_logits_capture_index == 0
+        assert specs[0].router_logits_capture_mode == "raw"
+
+    @pytest.mark.parametrize(("preset_model", "model_type"), [
+        ("mixtral", "mixtral"),
+        ("qwen3_moe", "qwen3_moe"),
+        ("qwen3_moe", "qwen2_moe"),
+    ])
+    def test_top_level_hf_router_capture_retargets_to_autoep_gate(self, monkeypatch, preset_model, model_type):
+        """HF OutputRecorder is retargeted from the native TopKRouter to AutoEP's raw gate projection."""
+
+        class FakeOutputRecorder:
+
+            def __init__(self, target_class, index=0, layer_name=None, class_name=None):
+                self.target_class = target_class
+                self.index = index
+                self.layer_name = layer_name
+                self.class_name = class_name
+
+        fake_output_capturing = types.ModuleType("transformers.utils.output_capturing")
+        fake_output_capturing.OutputRecorder = FakeOutputRecorder
+        fake_output_capturing._CAN_RECORD_REGISTRY = {}
+        monkeypatch.setitem(sys.modules, "transformers.utils.output_capturing", fake_output_capturing)
+
+        model = MockMoETransformer(num_layers=1, num_experts=4, moe_every_n=1)
+        model.config.model_type = model_type
+        model.config.num_experts = 4
+        model.model.layers[0].mlp.gate = MockRecordingRouter(64, 4, bias=False)
+        model._can_record_outputs = {"router_logits": FakeOutputRecorder(MockRecordingRouter, index=0)}
+        config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+            "preset_model": preset_model,
+            "use_grouped_mm": False,
+        })
+        auto_ep = AutoEP(model, config)
+        specs = auto_ep.ep_parser()
+
+        auto_ep.replace_moe_layer(specs[0], ep_size=1, ep_rank=0)
+
+        replacement = model.model.layers[0].mlp
+        recorder = model._can_record_outputs["router_logits"]
+        assert isinstance(replacement, AutoEPMoELayer)
+        assert recorder.target_class is replacement.router.gate.__class__
+        assert recorder.index == 0
+        assert recorder.layer_name == "router.gate"
+        output = replacement(torch.randn(2, 5, 64))
+        assert isinstance(output, torch.Tensor)
+
     def test_replace_moe_layer_works(self):
         """replace_moe_layer creates AutoEPMoELayer replacement."""
         from deepspeed.module_inject.auto_ep_layer import AutoEPMoELayer as _AutoEPMoELayer
@@ -1978,6 +2052,62 @@ class TestAutoEPMoELayerUnit:
         assert isinstance(replaced, AutoEPMoELayer)
         assert replaced._is_autoep_layer is True
 
+    def test_hf_mixtral_causal_lm_matches_autoep_with_router_logits(self):
+        """Tiny Mixtral CausalLM preserves router logits / aux loss after AutoEP replacement."""
+        transformers = pytest.importorskip("transformers")
+        if not hasattr(transformers, "MixtralConfig") or not hasattr(transformers, "MixtralForCausalLM"):
+            pytest.skip("Installed transformers does not expose MixtralConfig/MixtralForCausalLM")
+        if Version(transformers.__version__) < Version("5.0.0"):
+            pytest.skip("Mixtral AutoEP router-logit capture requires Transformers >= 5.0.0")
+
+        torch.manual_seed(1234)
+        config = transformers.MixtralConfig(
+            vocab_size=64,
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            max_position_embeddings=64,
+            num_local_experts=4,
+            num_experts_per_tok=2,
+            output_router_logits=True,
+            tie_word_embeddings=False,
+            use_cache=False,
+        )
+        native_model = transformers.MixtralForCausalLM(config)
+        autoep_model = transformers.MixtralForCausalLM(config)
+        autoep_model.load_state_dict(copy.deepcopy(native_model.state_dict()))
+
+        autoep_config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+            "preset_model": "mixtral",
+            "use_grouped_mm": False,
+        })
+        auto_ep = AutoEP(autoep_model, autoep_config)
+        specs = auto_ep.ep_parser()
+        assert len(specs) == 1
+        for spec in specs:
+            auto_ep.replace_moe_layer(spec, ep_size=1, ep_rank=0)
+
+        input_ids = torch.tensor([[1, 5, 7, 9, 11]], dtype=torch.long)
+        labels = input_ids.clone()
+        native_model.eval()
+        autoep_model.eval()
+        with torch.no_grad():
+            native_outputs = native_model(input_ids=input_ids, labels=labels, output_router_logits=True)
+            autoep_outputs = autoep_model(input_ids=input_ids, labels=labels, output_router_logits=True)
+
+        assert autoep_outputs.router_logits
+        assert autoep_outputs.aux_loss is not None
+        torch.testing.assert_close(autoep_outputs.router_logits[0],
+                                   native_outputs.router_logits[0],
+                                   rtol=1e-5,
+                                   atol=1e-6)
+        torch.testing.assert_close(autoep_outputs.aux_loss, native_outputs.aux_loss, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(autoep_outputs.loss, native_outputs.loss, rtol=1e-5, atol=1e-6)
+
     def test_hf_qwen2_direct_moe_can_use_qwen3_preset_when_fused_layout(self):
         """Qwen2-MoE can use the qwen3_moe preset when Transformers exposes the fused layout."""
         transformers = pytest.importorskip("transformers")
@@ -2001,7 +2131,7 @@ class TestAutoEPMoELayerUnit:
             num_experts=4,
             num_experts_per_tok=2,
             norm_topk_prob=True,
-            output_router_logits=False,
+            output_router_logits=True,
             tie_word_embeddings=False,
             use_cache=False,
             use_sliding_window=False,
@@ -2040,8 +2170,23 @@ class TestAutoEPMoELayerUnit:
 
         torch.testing.assert_close(autoep_output, native_output, rtol=1e-5, atol=1e-6)
 
-    def test_hf_qwen3_causal_lm_matches_autoep_ce_only(self):
-        """Tiny Qwen3 CE-only CausalLM matches AutoEP and stays ungated."""
+        input_ids = torch.tensor([[1, 5, 7, 9, 11]], dtype=torch.long)
+        labels = input_ids.clone()
+        with torch.no_grad():
+            native_outputs = native_model(input_ids=input_ids, labels=labels, output_router_logits=True)
+            autoep_outputs = autoep_model(input_ids=input_ids, labels=labels, output_router_logits=True)
+
+        assert autoep_outputs.router_logits
+        assert autoep_outputs.aux_loss is not None
+        torch.testing.assert_close(autoep_outputs.router_logits[0],
+                                   native_outputs.router_logits[0],
+                                   rtol=1e-5,
+                                   atol=1e-6)
+        torch.testing.assert_close(autoep_outputs.aux_loss, native_outputs.aux_loss, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(autoep_outputs.loss, native_outputs.loss, rtol=1e-5, atol=1e-6)
+
+    def test_hf_qwen3_causal_lm_matches_autoep_with_router_logits(self):
+        """Tiny Qwen3 CausalLM preserves router logits / aux loss after AutoEP replacement."""
         transformers = pytest.importorskip("transformers")
         if not hasattr(transformers, "Qwen3MoeConfig") or not hasattr(transformers, "Qwen3MoeForCausalLM"):
             pytest.skip("Installed transformers does not expose Qwen3MoeConfig/Qwen3MoeForCausalLM")
@@ -2062,7 +2207,7 @@ class TestAutoEPMoELayerUnit:
             num_experts=4,
             num_experts_per_tok=2,
             norm_topk_prob=True,
-            output_router_logits=False,
+            output_router_logits=True,
             tie_word_embeddings=False,
             use_cache=False,
             use_sliding_window=False,
@@ -2096,9 +2241,16 @@ class TestAutoEPMoELayerUnit:
         native_model.eval()
         autoep_model.eval()
         with torch.no_grad():
-            native_outputs = native_model(input_ids=input_ids, labels=labels, output_router_logits=False)
-            autoep_outputs = autoep_model(input_ids=input_ids, labels=labels, output_router_logits=False)
+            native_outputs = native_model(input_ids=input_ids, labels=labels, output_router_logits=True)
+            autoep_outputs = autoep_model(input_ids=input_ids, labels=labels, output_router_logits=True)
 
+        assert autoep_outputs.router_logits
+        assert autoep_outputs.aux_loss is not None
+        torch.testing.assert_close(autoep_outputs.router_logits[0],
+                                   native_outputs.router_logits[0],
+                                   rtol=1e-5,
+                                   atol=1e-6)
+        torch.testing.assert_close(autoep_outputs.aux_loss, native_outputs.aux_loss, rtol=1e-5, atol=1e-6)
         torch.testing.assert_close(autoep_outputs.logits, native_outputs.logits, rtol=1e-5, atol=1e-6)
         torch.testing.assert_close(autoep_outputs.loss, native_outputs.loss, rtol=1e-5, atol=1e-6)
 

--- a/tests/unit/moe/test_moe.py
+++ b/tests/unit/moe/test_moe.py
@@ -12,9 +12,49 @@ from unit.common import DistributedTest
 from unit.simple_model import SimplePRMoEModel, SimpleMoEModel, sequence_dataloader
 import deepspeed.comm as dist
 from deepspeed import get_accelerator
-from deepspeed.moe.sharded_moe import top1gating, topkgating
+from deepspeed.moe import sharded_moe
+from deepspeed.moe.sharded_moe import MOELayer, top1gating, top2gating, topkgating
 from deepspeed.moe.utils import split_params_into_different_moe_groups_for_optimizer, is_moe_param
 from deepspeed.utils.torch import required_torch_version
+
+
+class _DummyTop1Gate(torch.nn.Module):
+    k = 1
+
+    def _set_ep_group(self, ep_group):
+        self.ep_group = ep_group
+
+    def forward(self, reshaped_input, used_token=None):
+        tokens = reshaped_input.shape[0]
+        num_experts = 2
+        capacity = tokens
+        dispatch_mask = torch.zeros(tokens, num_experts, capacity, dtype=torch.bool, device=reshaped_input.device)
+        combine_weights = torch.zeros(tokens,
+                                      num_experts,
+                                      capacity,
+                                      dtype=reshaped_input.dtype,
+                                      device=reshaped_input.device)
+        for token_idx in range(tokens):
+            dispatch_mask[token_idx, token_idx % num_experts, token_idx] = True
+            combine_weights[token_idx, token_idx % num_experts, token_idx] = 1.0
+        l_aux = reshaped_input.new_tensor(0.0)
+        exp_counts = torch.tensor([tokens // 2, tokens - tokens // 2], device=reshaped_input.device)
+        return l_aux, combine_weights, dispatch_mask, exp_counts
+
+
+class _IdentityExperts(torch.nn.Module):
+
+    def forward(self, dispatched_input):
+        return dispatched_input
+
+
+def _run_no_drop_capacity_gating(gating_name, logits, ep_group):
+    if gating_name == "top1":
+        top1gating(logits, capacity_factor=1.0, min_capacity=0, drop_tokens=False, ep_group=ep_group)
+    elif gating_name == "top2":
+        top2gating(logits, capacity_factor=1.0, min_capacity=0, drop_tokens=False, ep_group=ep_group)
+    else:
+        topkgating(logits, k=2, capacity_factor=1.0, min_capacity=0, drop_tokens=False, ep_group=ep_group)
 
 
 @pytest.mark.parametrize("zero_stage", [0, 1, 2])
@@ -155,6 +195,75 @@ class TestMoE(DistributedTest):
             model.backward(loss)
             model.step()
             gc.collect()  # Must do this or we get a memory leak in this test
+
+
+class TestMoESingleton:
+
+    def test_ep_size_one_forward_skips_all_to_all(self, monkeypatch):
+        calls = []
+
+        def fail_all_to_all(*args, **kwargs):
+            calls.append((args, kwargs))
+            raise AssertionError("singleton MoE should not call all-to-all")
+
+        monkeypatch.setattr(sharded_moe._AllToAll, "apply", staticmethod(fail_all_to_all))
+        layer = MOELayer(_DummyTop1Gate(), _IdentityExperts(), "ep_size_1", ep_size=1, num_local_experts=2)
+        hidden_states = torch.randn(2, 3, 4)
+
+        output = layer(hidden_states, None)
+
+        assert output.shape == hidden_states.shape
+        assert calls == []
+
+    def test_multi_ep_forward_uses_all_to_all(self, monkeypatch):
+        calls = []
+
+        def passthrough_all_to_all(group, tensor):
+            calls.append((group, tensor.shape))
+            return tensor
+
+        monkeypatch.setattr(sharded_moe._AllToAll, "apply", staticmethod(passthrough_all_to_all))
+        layer = MOELayer(_DummyTop1Gate(), _IdentityExperts(), "ep_size_2", ep_size=2, num_local_experts=1)
+        hidden_states = torch.randn(2, 3, 4)
+
+        output = layer(hidden_states, None)
+
+        assert output.shape == hidden_states.shape
+        assert len(calls) == 2
+
+    @pytest.mark.parametrize("gating_name", ["top1", "top2", "topk"])
+    def test_capacity_no_all_reduce_when_ep_group_is_none(self, monkeypatch, gating_name):
+        calls = []
+        monkeypatch.setattr(sharded_moe.dist, "all_reduce", lambda *args, **kwargs: calls.append((args, kwargs)))
+        logits = torch.randn(8, 4)
+
+        _run_no_drop_capacity_gating(gating_name, logits, ep_group=None)
+
+        assert calls == []
+
+    @pytest.mark.parametrize("gating_name", ["top1", "top2", "topk"])
+    def test_capacity_no_all_reduce_for_singleton_ep_group(self, monkeypatch, gating_name):
+        calls = []
+        ep_group = object()
+        monkeypatch.setattr(sharded_moe.dist, "get_world_size", lambda group=None: 1)
+        monkeypatch.setattr(sharded_moe.dist, "all_reduce", lambda *args, **kwargs: calls.append((args, kwargs)))
+        logits = torch.randn(8, 4)
+
+        _run_no_drop_capacity_gating(gating_name, logits, ep_group=ep_group)
+
+        assert calls == []
+
+    @pytest.mark.parametrize("gating_name", ["top1", "top2", "topk"])
+    def test_capacity_all_reduce_for_multi_ep_group(self, monkeypatch, gating_name):
+        calls = []
+        ep_group = object()
+        monkeypatch.setattr(sharded_moe.dist, "get_world_size", lambda group=None: 2)
+        monkeypatch.setattr(sharded_moe.dist, "all_reduce", lambda *args, **kwargs: calls.append((args, kwargs)))
+        logits = torch.randn(8, 4)
+
+        _run_no_drop_capacity_gating(gating_name, logits, ep_group=ep_group)
+
+        assert len(calls) == 1
 
 
 @pytest.mark.parametrize("ep_size, use_residual", [(2, True), (2, False)])


### PR DESCRIPTION
This PR is intended to merge into the AutoEP PR #7938 branch (`tohtana/add_autoep`), not upstream `master` directly.

Summary:
- Retarget Mixtral/Qwen3-MoE/Qwen2-MoE-compatible HF router-logit capture to AutoEP raw gate logits while keeping MoE block tensor returns.
- Restore native MoE singleton local paths and capacity collective guards.
- Fail fast for unsupported AutoEP + AutoTP configs and document the limitation.

Testing:
- `git diff --check`
- `python -m compileall -q deepspeed/module_inject/auto_ep_presets/base.py deepspeed/module_inject/auto_ep_presets/mixtral.py deepspeed/module_inject/auto_ep_presets/qwen3_moe.py deepspeed/module_inject/auto_ep_preset_adapters.py deepspeed/module_inject/auto_ep_config.py deepspeed/moe/sharded_moe.py tests/unit/moe/test_autoep_unit.py tests/unit/moe/test_moe.py`
- `timeout 300 conda run -n ds pytest -q tests/unit/moe/test_autoep_unit.py::TestAutoEPConfig::test_validate_ep_rejects_autotp tests/unit/moe/test_autoep_unit.py::TestMoEDetection::test_top_level_hf_router_capture_contract_records_raw_logits_without_tuple_return tests/unit/moe/test_autoep_unit.py::TestMoEDetection::test_top_level_hf_router_capture_retargets_to_autoep_gate tests/unit/moe/test_autoep_unit.py::TestAutoEPMoELayerUnit::test_hf_mixtral_causal_lm_matches_autoep_with_router_logits tests/unit/moe/test_autoep_unit.py::TestAutoEPMoELayerUnit::test_hf_qwen2_direct_moe_can_use_qwen3_preset_when_fused_layout tests/unit/moe/test_autoep_unit.py::TestAutoEPMoELayerUnit::test_hf_qwen3_causal_lm_matches_autoep_with_router_logits tests/unit/moe/test_moe.py::TestMoESingleton` -> 18 passed, 3 skipped; Transformers 5.x HF smoke tests skipped in local env with Transformers 4.48.0.
- `timeout 300 conda run -n ds pre-commit run --files deepspeed/module_inject/auto_ep_presets/base.py deepspeed/module_inject/auto_ep_presets/mixtral.py deepspeed/module_inject/auto_ep_presets/qwen3_moe.py deepspeed/module_inject/auto_ep_preset_adapters.py deepspeed/module_inject/auto_ep_config.py deepspeed/moe/sharded_moe.py tests/unit/moe/test_autoep_unit.py tests/unit/moe/test_moe.py docs/_pages/config-json.md docs/code-docs/source/moe.rst` -> passed