### PR TITLE
AutoEP: support DeepSeek-V3 remote-code layout

### DIFF
--- a/deepspeed/module_inject/auto_ep.py
+++ b/deepspeed/module_inject/auto_ep.py
@@ -283,9 +283,11 @@ class AutoEP:
                     )
                     continue
 
+                expert_layout = adapter.resolve_expert_layout(experts_child, preset)
+
                 # Accept both: nn.ModuleList (legacy) and Experts class (transformers 5.0.0+)
                 has_expert_params = (isinstance(experts_child, nn.ModuleList)
-                                     or _has_3d_expert_params(experts_child, preset))
+                                     or _has_3d_expert_params(experts_child, expert_layout))
                 if not has_expert_params:
                     logger.debug(
                         "Skipping %s: '%s' child exists but has no expert parameters",
@@ -305,7 +307,7 @@ class AutoEP:
                     continue
 
                 # Detect storage format
-                storage = _detect_expert_storage(experts_child, preset)
+                storage = _detect_expert_storage(experts_child, expert_layout)
 
                 # Get num_experts and top_k from config or weights
                 num_experts = None
@@ -339,7 +341,7 @@ class AutoEP:
 
                 # Infer hidden sizes
                 try:
-                    hidden_size, ffn_hidden_size = _infer_hidden_and_ffn_size(experts_child, preset, storage,
+                    hidden_size, ffn_hidden_size = _infer_hidden_and_ffn_size(experts_child, expert_layout, storage,
                                                                               num_experts)
                 except ValueError as e:
                     logger.warning(f"Skipping {module_name}: {e}")
@@ -417,9 +419,9 @@ class AutoEP:
                     router_name=preset.router_pattern,
                     experts_name=preset.experts_pattern,
                     expert_storage=storage,
-                    expert_w1_name=preset.expert_w1,
-                    expert_w2_name=preset.expert_w2,
-                    expert_w3_name=preset.expert_w3,
+                    expert_w1_name=expert_layout.expert_w1,
+                    expert_w2_name=expert_layout.expert_w2,
+                    expert_w3_name=expert_layout.expert_w3,
                     num_experts=num_experts,
                     top_k=top_k,
                     hidden_size=hidden_size,

--- a/deepspeed/module_inject/auto_ep_presets/base.py
+++ b/deepspeed/module_inject/auto_ep_presets/base.py
@@ -246,6 +246,13 @@ class AutoEPPresetAdapter:
             num_limited_groups=config.num_limited_groups,
         )
 
+    def resolve_expert_layout(
+        self,
+        experts_module: nn.Module,
+        preset: MoEModelPreset,
+    ) -> MoEModelPreset:
+        return preset
+
     def adjust_forward_contract(self, contract: ForwardContract) -> ForwardContract:
         return contract
 

--- a/deepspeed/module_inject/auto_ep_presets/deepseek_v3.py
+++ b/deepspeed/module_inject/auto_ep_presets/deepseek_v3.py
@@ -4,6 +4,10 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
+import torch.nn as nn
+
 from deepspeed.module_inject.auto_ep_presets.base import AutoEPConfig, AutoEPPresetAdapter, GroupRoutingConfig, MoEModelPreset
 
 PRESET_NAME = "deepseek_v3"
@@ -52,6 +56,40 @@ class DeepSeekV3PresetAdapter(AutoEPPresetAdapter):
             num_limited_groups=group_routing.num_limited_groups or getattr(model_config, 'topk_group', None),
             group_score_func=group_routing.group_score_func,
         )
+
+    def resolve_expert_layout(
+        self,
+        experts_module: nn.Module,
+        preset: MoEModelPreset,
+    ) -> MoEModelPreset:
+        if not isinstance(experts_module, nn.ModuleList) or len(experts_module) == 0:
+            return preset
+
+        default_fused_layout = (preset.expert_storage == "fused_3d" and preset.expert_w1 == "gate_up_proj"
+                                and preset.expert_w2 == "down_proj" and preset.expert_w3 is None)
+        if not default_fused_layout:
+            return preset
+
+        expert0 = experts_module[0]
+        if not all(_has_expert_projection(expert0, name) for name in ("gate_proj", "up_proj", "down_proj")):
+            return preset
+
+        return replace(
+            preset,
+            expert_storage="module_list",
+            expert_w1="gate_proj",
+            expert_w2="down_proj",
+            expert_w3="up_proj",
+        )
+
+
+def _has_expert_projection(expert_module: nn.Module, name: str) -> bool:
+    projection = getattr(expert_module, name, None)
+    if projection is None:
+        return False
+    if isinstance(projection, (nn.Linear, nn.Parameter)):
+        return True
+    return hasattr(projection, "weight")
 
 
 PRESET_ADAPTERS = {

--- a/tests/unit/moe/test_autoep_unit.py
+++ b/tests/unit/moe/test_autoep_unit.py
@@ -846,6 +846,34 @@ class MockLlama4MoEBlock(nn.Module):
         self.shared_expert = MockSharedExpert(hidden_size)
 
 
+class MockDeepSeekV3Config:
+    model_type = "deepseek_v3"
+    n_routed_experts = 8
+    num_experts_per_tok = 2
+    hidden_size = 64
+    moe_intermediate_size = 128
+
+
+class MockDeepSeekV3Expert(nn.Module):
+    """Mimics a DeepSeek-V3 remote-code expert with split projections."""
+
+    def __init__(self, hidden_size=64, ffn_hidden=128):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_size, ffn_hidden, bias=False)
+        self.up_proj = nn.Linear(hidden_size, ffn_hidden, bias=False)
+        self.down_proj = nn.Linear(ffn_hidden, hidden_size, bias=False)
+
+
+class MockDeepSeekV3MoEBlock(nn.Module):
+    """Mimics model.layers.N.mlp for DeepSeek-V3 remote-code MoE layers."""
+
+    def __init__(self, num_experts=8, ffn_hidden=128, hidden_size=64):
+        super().__init__()
+        self.gate = nn.Linear(hidden_size, num_experts, bias=False)
+        self.experts = nn.ModuleList([MockDeepSeekV3Expert(hidden_size, ffn_hidden) for _ in range(num_experts)])
+        self.shared_experts = MockSharedExpert(hidden_size)
+
+
 class MockRecordingRouter(nn.Linear):
     _can_record_outputs = {"router_logits": {"index": 1, "layer_name": "router"}}
 
@@ -904,6 +932,22 @@ class MockLlama4Transformer(nn.Module):
         for _ in range(num_layers):
             layer = nn.Module()
             layer.feed_forward = MockLlama4MoEBlock(num_experts)
+            layers.append(layer)
+        self.model.layers = nn.ModuleList(layers)
+
+
+class MockDeepSeekV3Transformer(nn.Module):
+    """Minimal transformer with DeepSeek-V3 remote-code ModuleList experts."""
+
+    def __init__(self, num_layers=2, num_experts=8):
+        super().__init__()
+        self.config = MockDeepSeekV3Config()
+        self.config.n_routed_experts = num_experts
+        self.model = nn.Module()
+        layers = []
+        for _ in range(num_layers):
+            layer = nn.Module()
+            layer.mlp = MockDeepSeekV3MoEBlock(num_experts)
             layers.append(layer)
         self.model.layers = nn.ModuleList(layers)
 
@@ -1067,6 +1111,49 @@ class TestMoEDetection:
             assert spec.moe_output_shape == "flat"
             assert spec.has_shared_experts is True
             assert spec.shared_experts_name == "shared_expert"
+
+    def test_deepseek_v3_detects_module_list_split_experts(self, monkeypatch):
+        """DeepSeek-V3 remote-code ModuleList experts use split projection names."""
+        adapter = get_preset_adapter("deepseek_v3")
+        monkeypatch.setattr(adapter, "_installed_transformers_version", lambda: "5.0.0")
+        model = MockDeepSeekV3Transformer(num_layers=2, num_experts=8)
+        config = AutoEPConfig(enabled=True, autoep_size=2)
+
+        specs = AutoEP(model, config).ep_parser()
+
+        assert len(specs) == 2
+        for spec in specs:
+            assert spec.model_family == "deepseek_v3"
+            assert spec.expert_storage == "module_list"
+            assert spec.expert_w1_name == "gate_proj"
+            assert spec.expert_w2_name == "down_proj"
+            assert spec.expert_w3_name == "up_proj"
+            assert spec.hidden_size == 64
+            assert spec.ffn_hidden_size == 128
+            assert spec.score_func == "sigmoid"
+            assert spec.route_norm is False
+            assert spec.has_shared_experts is True
+            assert spec.shared_experts_name == "shared_experts"
+
+    def test_deepseek_v3_keeps_fused_gate_up_layout(self, monkeypatch):
+        """DeepSeek-V3 Transformers 5.x fused experts keep gate_up_proj layout."""
+        adapter = get_preset_adapter("deepseek_v3")
+        monkeypatch.setattr(adapter, "_installed_transformers_version", lambda: "5.0.0")
+        model = MockMoETransformer(num_layers=1, num_experts=8, moe_every_n=1)
+        model.config.model_type = "deepseek_v3"
+        model.config.n_routed_experts = 8
+        model.config.num_experts_per_tok = 2
+        config = AutoEPConfig(enabled=True, autoep_size=2)
+
+        specs = AutoEP(model, config).ep_parser()
+
+        assert len(specs) == 1
+        spec = specs[0]
+        assert spec.model_family == "deepseek_v3"
+        assert spec.expert_storage == "fused_3d"
+        assert spec.expert_w1_name == "gate_up_proj"
+        assert spec.expert_w2_name == "down_proj"
+        assert spec.expert_w3_name is None
 
     def test_detect_llama4_router_capture_still_returns_tuple(self):
         """Router-level output recording must not suppress Llama4's MoE tuple contract."""
@@ -1889,6 +1976,42 @@ class TestWeightRepacking:
         assert torch.equal(w1, expected_w1)
         assert torch.equal(w2, expected_w2)
         assert torch.equal(w3, expected_w3)
+
+    def test_repack_module_list_separate_gate_and_up(self):
+        experts = nn.ModuleList([MockDeepSeekV3Expert(hidden_size=64, ffn_hidden=128) for _ in range(8)])
+        spec = MoELayerSpec(
+            moe_module_name="test",
+            model_family="deepseek_v3",
+            router_name="gate",
+            experts_name="experts",
+            expert_storage="module_list",
+            expert_w1_name="gate_proj",
+            expert_w2_name="down_proj",
+            expert_w3_name="up_proj",
+            num_experts=8,
+            top_k=2,
+            hidden_size=64,
+            ffn_hidden_size=128,
+            score_func="sigmoid",
+            score_apply="post",
+            route_norm=False,
+            gate_bias=False,
+            return_router_logits=False,
+            router_logits_capture_target="none",
+            router_logits_capture_index=None,
+            router_logits_capture_layer_name=None,
+            has_shared_experts=True,
+            shared_experts_name="shared_experts",
+        )
+
+        w1, w2, w3 = repack_expert_weights(experts, spec, ep_rank=0, ep_size=2)
+
+        assert w1.shape == (4, 128, 64)
+        assert w2.shape == (4, 64, 128)
+        assert w3.shape == (4, 128, 64)
+        assert torch.equal(w1[0], experts[0].gate_proj.weight.data)
+        assert torch.equal(w2[0], experts[0].down_proj.weight.data)
+        assert torch.equal(w3[0], experts[0].up_proj.weight.data)
 
 
 # === Phase 5: AutoEP MoE Layer and Orchestrator ===


### PR DESCRIPTION
This PR is intended to merge into the fork-local PR #7938 integration branch, represented here by `tohtana/add_autoep`. It does not create or update anything in `deepspeedai/DeepSpeed`.

## Summary
- Add an AutoEP preset-adapter hook for expert layout resolution.
- Teach the DeepSeek-V3 adapter to retarget only the remote-code `nn.ModuleList` split expert layout to `gate_proj` / `down_proj` / `up_proj`.
- Preserve the existing Transformers 5.x fused `gate_up_proj` / `down_proj` layout with `expert_w3=None`.
- Add regression tests for split ModuleList detection, split ModuleList repacking, and fused DeepSeek-V3 layout preservation.

## Testing
- `PYTHONPATH=$PWD /mnt/local_storage/dev_ds_venvs/autoep-deepseek-tf5/bin/python -m pytest -q tests/unit/moe/test_autoep_unit.py -k 'deepseek_v3 or repack_module_list_separate_gate_and_up'`
- `PYTHONPATH=$PWD /mnt/local_storage/dev_ds_venvs/autoep-deepseek-tf5/bin/python -m pytest -q tests/unit/moe/test_autoep_unit.py -k deepseek`
- `pre-commit run --files deepspeed/module_inject/auto_ep.py deepspeed/module_inject/auto_ep_presets/base.py deepspeed/module_inject/auto_ep_presets/deepseek_v3.py tests/unit/moe/test_autoep_unit.py`
