### PR TITLE
AutoEP PR #7938 review cleanups

### DIFF
--- a/deepspeed/module_inject/auto_ep.py
+++ b/deepspeed/module_inject/auto_ep.py
@@ -17,7 +17,6 @@ from typing import Literal
 import torch
 import torch.nn as nn
 
-from deepspeed.utils import logger
 from deepspeed.module_inject.auto_ep_config import (
     AutoEPConfig,
     MoELayerSpec,
@@ -31,6 +30,8 @@ from deepspeed.module_inject.auto_ep_presets.registry import (
     resolve_preset_candidates,
     unsupported_preset_for_hf_model_type,
 )
+from deepspeed.moe.fused_expert_layout import classify_fused_gate_up_layout
+from deepspeed.utils import logger
 
 
 def _remove_transformers_output_capture_hooks(model: nn.Module) -> int:
@@ -144,26 +145,14 @@ def _infer_hidden_and_ffn_size(
         w2_param = getattr(experts_module, preset.expert_w2, None)
         if w1_param is not None and w2_param is not None:
             if preset.expert_w3 is None:
-                # Most HF MoE families store fused gate+up as [E, 2*ffn, hidden]
-                # with down_proj as [E, hidden, ffn]. Llama4 stores the transpose:
-                # gate_up_proj [E, hidden, 2*ffn] and down_proj [E, ffn, hidden].
-                if w1_param.shape[1] % 2 == 0 and tuple(w2_param.shape[1:]) == (
-                        w1_param.shape[2],
-                        w1_param.shape[1] // 2,
-                ):
-                    hidden_size = w1_param.shape[2]
-                    ffn_hidden_size = w1_param.shape[1] // 2
-                elif w1_param.shape[2] % 2 == 0 and tuple(w2_param.shape[1:]) == (
-                        w1_param.shape[2] // 2,
-                        w1_param.shape[1],
-                ):
-                    hidden_size = w1_param.shape[1]
-                    ffn_hidden_size = w1_param.shape[2] // 2
-                else:
+                layout = classify_fused_gate_up_layout(tuple(w1_param.shape), tuple(w2_param.shape))
+                if layout is None:
                     raise ValueError("expert_w3=None expects fused gate+up weights with either "
                                      f"[E, 2*ffn, hidden]/[E, hidden, ffn] or [E, hidden, 2*ffn]/[E, ffn, hidden], "
                                      f"but got {preset.expert_w1}={tuple(w1_param.shape)} and "
                                      f"{preset.expert_w2}={tuple(w2_param.shape)}.")
+                hidden_size = layout.hidden_size
+                ffn_hidden_size = layout.ffn_hidden_size
             else:
                 # Separate gate and up: w1 shape is [E, ffn, hidden]
                 w3_param = getattr(experts_module, preset.expert_w3, None)
@@ -342,6 +331,9 @@ class AutoEP:
                     hidden_size, ffn_hidden_size = _infer_hidden_and_ffn_size(experts_child, preset, storage,
                                                                               num_experts)
                 except ValueError as e:
+                    if self._requires_selected_preset_detection():
+                        raise ValueError(f"AutoEP: preset '{preset_name}' matched layer '{module_name}' "
+                                         f"with router and experts, but shape inference failed: {e}") from e
                     logger.warning(f"Skipping {module_name}: {e}")
                     continue
 

--- a/deepspeed/moe/ep_kernels.py
+++ b/deepspeed/moe/ep_kernels.py
@@ -25,6 +25,8 @@ from typing import Callable
 import torch
 import torch.nn as nn
 
+from deepspeed.moe.ep_count import count_tokens_per_expert
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -366,13 +368,7 @@ class TokenReorderer(nn.Module):
                   token-slot indices sorted by expert.
                 - num_tokens_per_expert ``(num_experts,)``: histogram.
         """
-        # histc requires float input on CPU, so cast indices
-        num_tokens_per_expert = torch.histc(
-            selected_experts_indices.view(-1).float(),
-            bins=self.num_experts,
-            min=0,
-            max=self.num_experts,
-        )
+        num_tokens_per_expert = count_tokens_per_expert(selected_experts_indices, self.num_experts)
 
         token_indices_experts_sorted = torch.argsort(selected_experts_indices.view(-1), stable=True)
 

--- a/deepspeed/moe/ep_repack.py
+++ b/deepspeed/moe/ep_repack.py
@@ -14,6 +14,7 @@ import torch
 import torch.nn as nn
 
 from deepspeed.module_inject.auto_ep_config import MoELayerSpec
+from deepspeed.moe.fused_expert_layout import classify_fused_gate_up_layout
 
 
 def repack_expert_weights(
@@ -75,28 +76,21 @@ def _repack_fused_3d(
     w2_local = w2_full[expert_start:expert_end].clone()
 
     if spec.expert_w3_name is None:
-        if w1_local.shape[1] % 2 == 0 and tuple(w2_local.shape[1:]) == (
-                w1_local.shape[2],
-                w1_local.shape[1] // 2,
-        ):
-            # Standard fused gate+up: gate_up_proj [E, 2*ffn, hidden]
-            ffn_hidden = w1_local.shape[1] // 2
-            w1 = w1_local[:, :ffn_hidden, :].contiguous()  # [E_local, ffn, hidden]
-            w3 = w1_local[:, ffn_hidden:, :].contiguous()  # [E_local, ffn, hidden]
-            w2 = w2_local.contiguous()  # [E_local, hidden, ffn]
-        elif w1_local.shape[2] % 2 == 0 and tuple(w2_local.shape[1:]) == (
-                w1_local.shape[2] // 2,
-                w1_local.shape[1],
-        ):
-            # Llama4 fused gate+up: gate_up_proj [E, hidden, 2*ffn]
-            ffn_hidden = w1_local.shape[2] // 2
-            w1 = w1_local[:, :, :ffn_hidden].transpose(1, 2).contiguous()  # [E_local, ffn, hidden]
-            w3 = w1_local[:, :, ffn_hidden:].transpose(1, 2).contiguous()  # [E_local, ffn, hidden]
-            w2 = w2_local.transpose(1, 2).contiguous()  # [E_local, hidden, ffn]
-        else:
+        layout = classify_fused_gate_up_layout(tuple(w1_local.shape), tuple(w2_local.shape))
+        if layout is None:
             raise ValueError("Unsupported fused expert weight layout for AutoEP repacking: "
                              f"{spec.expert_w1_name}={tuple(w1_local.shape)}, "
                              f"{spec.expert_w2_name}={tuple(w2_local.shape)}")
+
+        ffn_hidden = layout.ffn_hidden_size
+        if layout.layout == "gate_up_first":
+            w1 = w1_local[:, :ffn_hidden, :].contiguous()  # [E_local, ffn, hidden]
+            w3 = w1_local[:, ffn_hidden:, :].contiguous()  # [E_local, ffn, hidden]
+            w2 = w2_local.contiguous()  # [E_local, hidden, ffn]
+        else:
+            w1 = w1_local[:, :, :ffn_hidden].transpose(1, 2).contiguous()  # [E_local, ffn, hidden]
+            w3 = w1_local[:, :, ffn_hidden:].transpose(1, 2).contiguous()  # [E_local, ffn, hidden]
+            w2 = w2_local.transpose(1, 2).contiguous()  # [E_local, hidden, ffn]
     else:
         # Separate w1 (gate), w3 (up)
         w3_full = getattr(experts_source, spec.expert_w3_name)

--- a/deepspeed/moe/ep_router.py
+++ b/deepspeed/moe/ep_router.py
@@ -19,6 +19,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from deepspeed.moe.ep_count import count_tokens_per_expert
+
 
 class TokenChoiceTopKRouter(nn.Module):
     """Token-choice top-K routing for Mixture of Experts.
@@ -171,13 +173,6 @@ class TokenChoiceTopKRouter(nn.Module):
 
         top_scores = top_scores * self.route_scale
 
-        # Count tokens per expert
-        # histc requires float input on CPU, so cast indices
-        num_tokens_per_expert = torch.histc(
-            selected_experts_indices.view(-1).float(),
-            bins=self.num_experts,
-            min=0,
-            max=self.num_experts,
-        )
+        num_tokens_per_expert = count_tokens_per_expert(selected_experts_indices, self.num_experts)
 
         return top_scores, selected_experts_indices, num_tokens_per_expert

--- a/deepspeed/moe/fused_expert_layout.py
+++ b/deepspeed/moe/fused_expert_layout.py
@@ -1,0 +1,47 @@
+# Copyright (c) DeepSpeed Team.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+"""Shape helpers for fused gate/up expert tensors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+FusedLayout = Literal["gate_up_first", "hidden_first"]
+
+
+@dataclass(frozen=True)
+class FusedExpertLayout:
+    layout: FusedLayout
+    hidden_size: int
+    ffn_hidden_size: int
+    needs_transpose: bool
+
+
+def classify_fused_gate_up_layout(
+    w1_shape: tuple[int, ...],
+    w2_shape: tuple[int, ...],
+) -> FusedExpertLayout | None:
+    """Classify fused gate/up expert weights from raw tensor shapes."""
+    if len(w1_shape) != 3 or len(w2_shape) != 3:
+        return None
+
+    if w1_shape[1] % 2 == 0 and w2_shape[1:] == (w1_shape[2], w1_shape[1] // 2):
+        return FusedExpertLayout(
+            layout="gate_up_first",
+            hidden_size=w1_shape[2],
+            ffn_hidden_size=w1_shape[1] // 2,
+            needs_transpose=False,
+        )
+
+    if w1_shape[2] % 2 == 0 and w2_shape[1:] == (w1_shape[2] // 2, w1_shape[1]):
+        return FusedExpertLayout(
+            layout="hidden_first",
+            hidden_size=w1_shape[1],
+            ffn_hidden_size=w1_shape[2] // 2,
+            needs_transpose=True,
+        )
+
+    return None

--- a/deepspeed/moe/sharded_moe.py
+++ b/deepspeed/moe/sharded_moe.py
@@ -215,7 +215,7 @@ def top1gating(logits: Tensor,
     if not drop_tokens:
         new_capacity = torch.max(exp_counts).to(logits.device)
         # Communicate across expert processes to pick the maximum capacity.
-        if ep_group is not None:
+        if ep_group is not None and dist.get_world_size(group=ep_group) > 1:
             dist.all_reduce(new_capacity, op=dist.ReduceOp.MAX, group=ep_group)
         if groups._get_expert_model_parallel_world_size() == 1:
             # If the non-expert is tensor-parallel, we need to pad the capacity to 'tp'.
@@ -335,7 +335,7 @@ def top2gating(logits: Tensor,
     else:
         # Do not drop tokens - set capacity according to current expert assignments
         new_capacity = torch.max(exp_counts)
-        if ep_group is not None:
+        if ep_group is not None and dist.get_world_size(group=ep_group) > 1:
             dist.all_reduce(new_capacity, op=dist.ReduceOp.MAX, group=ep_group)
         if groups._get_expert_model_parallel_world_size() == 1:
             # If the non-expert is tensor-parallel, we need to pad the capacity to 'tp'.
@@ -421,7 +421,7 @@ def topkgating(
     else:
         # Do not drop tokens - set capacity according to current expert assignments
         new_capacity = torch.max(exp_counts)
-        if ep_group is not None:
+        if ep_group is not None and dist.get_world_size(group=ep_group) > 1:
             dist.all_reduce(new_capacity, op=dist.ReduceOp.MAX, group=ep_group)
         if groups._get_expert_model_parallel_world_size() == 1:
             # If the non-expert is tensor-parallel, we need to pad the capacity to 'tp'.
@@ -628,7 +628,10 @@ class MOELayer(Base):
             # an allgather to ensure correctness,
             dispatched_input = drop_tokens(dispatched_input, dim=1)
 
-        dispatched_input = _AllToAll.apply(self.ep_group, dispatched_input)
+        if self.ep_size > 1:
+            dispatched_input = _AllToAll.apply(self.ep_group, dispatched_input)
+        else:
+            dispatched_input = dispatched_input.contiguous()
 
         if self.wall_clock_breakdown:
             self.timers(FIRST_ALLTOALL_TIMER).stop()
@@ -654,7 +657,10 @@ class MOELayer(Base):
         if self.wall_clock_breakdown:
             self.timers(SECOND_ALLTOALL_TIMER).start()
 
-        expert_output = _AllToAll.apply(self.ep_group, expert_output)
+        if self.ep_size > 1:
+            expert_output = _AllToAll.apply(self.ep_group, expert_output)
+        else:
+            expert_output = expert_output.contiguous()
 
         if self.wall_clock_breakdown:
             self.timers(SECOND_ALLTOALL_TIMER).stop()

--- a/tests/unit/moe/test_autoep_unit.py
+++ b/tests/unit/moe/test_autoep_unit.py
@@ -565,6 +565,8 @@ class TestTokenChoiceTopKRouter:
         assert top_scores.shape == (100, 2)
         assert selected_experts.shape == (100, 2)
         assert num_tokens.shape == (8, )
+        expected_counts = torch.bincount(selected_experts.reshape(-1), minlength=8).to(num_tokens.dtype)
+        assert torch.equal(num_tokens, expected_counts)
 
     def test_router_softmax_scores_sum(self):
         router = TokenChoiceTopKRouter(dim=64,
@@ -745,6 +747,8 @@ class TestTokenReorderer:
         assert scores_sorted.shape == (100, )
         assert indices_sorted.shape == (100, )
         assert num_tokens.shape == (8, )
+        expected_counts = torch.bincount(selected_experts.reshape(-1), minlength=8).to(num_tokens.dtype)
+        assert torch.equal(num_tokens, expected_counts)
 
     def test_token_reorderer_index_coverage(self):
         reorderer = TokenReorderer(num_experts=4, top_k=2)
@@ -808,6 +812,23 @@ class MockMoEBlock(nn.Module):
         super().__init__()
         self.gate = nn.Linear(hidden_size, num_experts, bias=False)
         self.experts = MockMoEExperts(num_experts, ffn_hidden, hidden_size)
+
+
+class MockUnsupportedFusedExperts(nn.Module):
+    """Fused expert storage with router-compatible but unsupported shapes."""
+
+    def __init__(self, num_experts=8, hidden_size=64):
+        super().__init__()
+        self.gate_up_proj = nn.Parameter(torch.randn(num_experts, hidden_size, hidden_size))
+        self.down_proj = nn.Parameter(torch.randn(num_experts, hidden_size, hidden_size))
+
+
+class MockUnsupportedFusedMoEBlock(nn.Module):
+
+    def __init__(self, num_experts=8, hidden_size=64):
+        super().__init__()
+        self.gate = nn.Linear(hidden_size, num_experts, bias=False)
+        self.experts = MockUnsupportedFusedExperts(num_experts, hidden_size)
 
 
 class MockLlama4Config:
@@ -964,6 +985,62 @@ class TestMoEDetection:
         assert len(specs) == 2
         module_names = [s.moe_module_name for s in specs]
         assert "model.layers.1.mlp" not in module_names
+
+    def test_explicit_preset_raises_on_matching_layer_with_unsupported_shapes(self):
+        model = MockMoETransformer(num_layers=1, moe_every_n=1)
+        model.model.layers[0].mlp = MockUnsupportedFusedMoEBlock()
+        config = AutoEPConfig(enabled=True, autoep_size=1, preset_model="mixtral")
+
+        with pytest.raises(ValueError) as exc:
+            AutoEP(model, config).ep_parser()
+
+        message = str(exc.value)
+        assert "preset 'mixtral'" in message
+        assert "model.layers.0.mlp" in message
+        assert "shape inference failed" in message
+        assert "gate_up_proj" in message
+
+    def test_auto_detected_known_preset_raises_on_matching_layer_with_unsupported_shapes(self):
+        model = MockMoETransformer(num_layers=1, moe_every_n=1)
+        model.model.layers[0].mlp = MockUnsupportedFusedMoEBlock()
+        config = AutoEPConfig(enabled=True, autoep_size=1)
+
+        with pytest.raises(ValueError) as exc:
+            AutoEP(model, config).ep_parser()
+
+        message = str(exc.value)
+        assert "preset 'mixtral'" in message
+        assert "model.layers.0.mlp" in message
+        assert "shape inference failed" in message
+
+    def test_explicit_custom_pattern_raises_on_matching_layer_with_unsupported_shapes(self):
+        model = MockMoETransformer(num_layers=1, moe_every_n=1)
+        model.config.model_type = "custom"
+        model.model.layers[0].mlp = MockUnsupportedFusedMoEBlock()
+        config = AutoEPConfig(
+            enabled=True,
+            autoep_size=1,
+            moe_layer_pattern=r"model\.layers\.\d+\.mlp",
+            router_pattern="gate",
+            expert_pattern="experts",
+            expert_w3=None,
+            top_k=2,
+        )
+
+        with pytest.raises(ValueError) as exc:
+            AutoEP(model, config).ep_parser()
+
+        message = str(exc.value)
+        assert "preset 'custom'" in message
+        assert "shape inference failed" in message
+
+    def test_generic_detection_skips_matching_layer_with_unsupported_shapes(self):
+        model = MockMoETransformer(num_layers=1, moe_every_n=1)
+        model.config.model_type = "custom"
+        model.model.layers[0].mlp = MockUnsupportedFusedMoEBlock()
+        config = AutoEPConfig(enabled=True, autoep_size=1)
+
+        assert AutoEP(model, config).ep_parser() == []
 
     def test_explicit_preset_without_matching_moe_layers_fails_actionably(self):
         """An explicit preset should not silently no-op when its structure is absent."""
@@ -1173,7 +1250,7 @@ class TestMoEDetection:
             "enabled": True,
             "autoep_size": 1,
         })
-        adapter = get_preset_adapter("default")
+        adapter = get_preset_adapter(PRESET_MODELS["mixtral"].preset_adapter)
         calls = []
 
         def record_validation(preset_name, preset, model_config):

--- a/tests/unit/moe/test_fused_expert_layout.py
+++ b/tests/unit/moe/test_fused_expert_layout.py
@@ -1,0 +1,38 @@
+# Copyright (c) DeepSpeed Team.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from deepspeed.moe.fused_expert_layout import classify_fused_gate_up_layout
+
+
+def test_classifies_gate_up_first():
+    layout = classify_fused_gate_up_layout((8, 256, 64), (8, 64, 128))
+
+    assert layout is not None
+    assert layout.layout == "gate_up_first"
+    assert layout.hidden_size == 64
+    assert layout.ffn_hidden_size == 128
+    assert layout.needs_transpose is False
+
+
+def test_classifies_hidden_first():
+    layout = classify_fused_gate_up_layout((8, 64, 256), (8, 128, 64))
+
+    assert layout is not None
+    assert layout.layout == "hidden_first"
+    assert layout.hidden_size == 64
+    assert layout.ffn_hidden_size == 128
+    assert layout.needs_transpose is True
+
+
+def test_returns_none_for_unknown_layout():
+    assert classify_fused_gate_up_layout((8, 64, 64), (8, 64, 64)) is None
+
+
+def test_returns_none_for_odd_inner_dim():
+    assert classify_fused_gate_up_layout((8, 255, 64), (8, 64, 127)) is None
+
+
+def test_returns_none_for_non_3d():
+    assert classify_fused_gate_up_layout((64, 64), (64, 64)) is None

--- a/tests/unit/moe/test_moe.py
+++ b/tests/unit/moe/test_moe.py
@@ -11,8 +11,10 @@ import random
 from unit.common import DistributedTest
 from unit.simple_model import SimplePRMoEModel, SimpleMoEModel, sequence_dataloader
 import deepspeed.comm as dist
+import deepspeed.moe.sharded_moe as sharded_moe
 from deepspeed import get_accelerator
-from deepspeed.moe.sharded_moe import top1gating, topkgating
+from deepspeed.moe.layer import MoE
+from deepspeed.moe.sharded_moe import top1gating, top2gating, topkgating
 from deepspeed.moe.utils import split_params_into_different_moe_groups_for_optimizer, is_moe_param
 from deepspeed.utils.torch import required_torch_version
 
@@ -207,6 +209,93 @@ class TestTopk(DistributedTest):
                             drop_tokens=False,
                             use_rts=True,
                             use_tutel=False)
+
+
+class TestMoESingleton(DistributedTest):
+    world_size = 2
+
+    @pytest.mark.parametrize("ep_size, expected_calls", [(1, 0), (2, 2)], ids=["single", "multi"])
+    def test_all_to_all(self, monkeypatch, ep_size, expected_calls):
+        if not required_torch_version(min_version=1.8):
+            pytest.skip("DeepSpeed MoE tests need torch 1.8 or higher to run correctly")
+
+        config_dict = {"train_micro_batch_size_per_gpu": 1, "steps_per_print": 1}
+        hidden_dim = 8
+        expert = torch.nn.Sequential(torch.nn.Linear(hidden_dim, hidden_dim), torch.nn.Linear(hidden_dim, hidden_dim))
+        model = MoE(hidden_size=hidden_dim, expert=expert, num_experts=2, ep_size=ep_size, k=1, min_capacity=0)
+        optimizer = torch.optim.AdamW(params=model.parameters())
+        model, _, _, _ = deepspeed.initialize(config=config_dict,
+                                              model=model,
+                                              optimizer=optimizer,
+                                              dist_init_required=False)
+
+        all_to_all_calls = []
+
+        def counted_all_to_all(group, input):
+            all_to_all_calls.append((group, input.shape))
+            return input
+
+        monkeypatch.setattr(sharded_moe._AllToAll, "apply", counted_all_to_all)
+
+        x = torch.randn(1, 4, hidden_dim, device=model.device, requires_grad=True)
+        output, l_aux, _ = model(x)
+        assert len(all_to_all_calls) == expected_calls
+
+        loss = output.float().sum() + l_aux.float()
+        model.backward(loss)
+        assert len(all_to_all_calls) == expected_calls
+        assert x.grad is not None
+        assert any(param.grad is not None for param in model.module.parameters())
+
+    @pytest.mark.parametrize("gate_fn, capacity_args", [(top1gating, (1, 0)), (top2gating, (1, 0)),
+                                                        (topkgating, (3, 1, 0))],
+                             ids=["top1", "top2", "topk"])
+    @pytest.mark.parametrize("ep_world_size, expected_calls", [(1, 0), (2, 1)], ids=["single", "multi"])
+    def test_capacity(self, monkeypatch, gate_fn, capacity_args, ep_world_size, expected_calls):
+        if not required_torch_version(min_version=1.8):
+            pytest.skip("DeepSpeed MoE tests need torch 1.8 or higher to run correctly")
+
+        ep_group = None
+        if ep_world_size == 1:
+            for rank in range(dist.get_world_size()):
+                group = dist.new_group([rank])
+                if rank == dist.get_rank():
+                    ep_group = group
+        else:
+            ep_group = dist.new_group(list(range(dist.get_world_size())))
+
+        all_reduce_calls = []
+        original_all_reduce = sharded_moe.dist.all_reduce
+
+        def counted_all_reduce(tensor, op=dist.ReduceOp.SUM, group=None):
+            all_reduce_calls.append((tensor, op, group))
+            return original_all_reduce(tensor, op=op, group=group)
+
+        monkeypatch.setattr(sharded_moe.dist, "all_reduce", counted_all_reduce)
+
+        device = get_accelerator().current_device_name()
+        logits = torch.randn(8, 4, device=device)
+        gate_fn(logits, *capacity_args, drop_tokens=False, ep_group=ep_group)
+
+        assert len(all_reduce_calls) == expected_calls
+        if all_reduce_calls:
+            _, op, group = all_reduce_calls[0]
+            assert op == dist.ReduceOp.MAX
+            assert group is ep_group
+
+    def test_no_ep_group(self, monkeypatch):
+        if not required_torch_version(min_version=1.8):
+            pytest.skip("DeepSpeed MoE tests need torch 1.8 or higher to run correctly")
+
+        def fail_collective(*args, **kwargs):
+            raise AssertionError("ep_group=None should not enter expert-parallel collective code")
+
+        monkeypatch.setattr(sharded_moe.dist, "get_world_size", fail_collective)
+        monkeypatch.setattr(sharded_moe.dist, "all_reduce", fail_collective)
+
+        device = get_accelerator().current_device_name()
+        logits = torch.randn(8, 4, device=device)
+        top2gating(logits, 1, 0, drop_tokens=False, ep_group=None, top2_2nd_expert_sampling=False)
 
 
 class TestTopkGate(DistributedTest):

--- a/tests/unit/moe/test_moe.py
+++ b/tests/unit/moe/test_moe.py
@@ -241,13 +241,13 @@ class TestTopkGate(DistributedTest):
         logits2 *= dist.get_rank() + 1
 
         #top3 full mask     #prob_mask          #postion_mask
-        #0 0 1 0 1 1        #0 0 1 0 1 1        #0 0 1 0 1 1
-        #0 1 0 1 0 1        #0 0 0 1 0 0        #0 1 0 1 0 1
+        #0 0 1 0 1 1        #0 0 1 0 1 0        #0 0 1 0 1 1
+        #0 1 0 1 0 1        #0 1 0 1 0 1        #0 1 0 1 0 1
         #0 1 1 1 0 0        #0 1 1 1 0 0        #0 1 1 1 0 0
-        #1 1 0 0 0 1        #1 1 0 0 0 1        #1 0 0 0 0 0
+        #1 1 0 0 0 1        #1 0 0 0 0 1        #1 0 0 0 0 0
         probs_dispatch_res = topkgating(logits2, 3, 1, min_capacity=1, drop_policy='probs')[2]
-        probs_sec_sparse = torch.tensor([[0, 2, 0], [0, 4, 0], [0, 5, 0], [1, 3, 0], [2, 1, 0], [2, 2, 1], [2, 3, 1],
-                                         [3, 0, 0], [3, 1, 1], [3, 5, 1]])
+        probs_sec_sparse = torch.tensor([[0, 2, 0], [0, 4, 0], [1, 1, 0], [1, 3, 0], [1, 5, 0], [2, 1, 1], [2, 2, 1],
+                                         [2, 3, 1], [3, 0, 0], [3, 5, 1]])
         check_equal(logits2, 2, probs_sec_sparse, probs_dispatch_res)
 
         position_sec_sparse = torch.tensor([[0, 2, 0], [0, 4, 0], [0, 5, 0], [1, 1, 0], [1, 3, 0], [1, 5, 1],


### PR DESCRIPTION
## Summary
- factor fused gate/up expert shape classification into a shared AutoEP helper
- make preset/custom-pattern detection fail clearly on matching MoE layers with unsupported expert shapes, while generic detection keeps skipping unsupported matches
- replace float histogram token counts with integer bincount-based counts in routing/kernel paths
- add regression coverage for unsupported fused layouts and shared layout classification

Tracks tohtana/dev_ds#102.

## Validation
- `/mnt/local_storage/dev_ds_conda_envs/autoep-tf5-baseclone/bin/python -m compileall -q deepspeed/module_inject/auto_ep.py deepspeed/moe/fused_expert_layout.py deepspeed/moe/ep_repack.py deepspeed/moe/ep_router.py deepspeed/moe/ep_kernels.py tests/unit/moe/test_autoep_unit.py tests/unit/moe/test_fused_expert_layout.py`
- `/mnt/local_storage/dev_ds_conda_envs/autoep-tf5-baseclone/bin/python -m pytest tests/unit/moe/test_fused_expert_layout.py -q` (5 passed)
- `/mnt/local_storage/dev_ds_conda_envs/autoep-tf5-baseclone/bin/python -m pytest tests/unit/moe/test_autoep_unit.py -q -k 'unsupported_shapes or generic_detection or token or fused_3d or llama4_hidden_first'` (21 passed, 166 deselected)
- `/mnt/local_storage/dev_ds_conda_envs/autoep-tf5-baseclone/bin/python -m pytest tests/unit/moe/test_moe.py -q -k 'MoESingleton or Topk'` (11 passed, 20 deselected, first run)
- `pre-commit run --files deepspeed/module_inject/auto_ep.py deepspeed/moe/ep_kernels.py deepspeed/moe/ep_repack.py deepspeed/moe/ep_router.py deepspeed/moe/fused_expert_layout.py tests/unit/moe/test_autoep_unit.py tests/unit/moe/test_fused_expert_layout.py`
- `git diff --check --cached`

Note: a later repeat of the `test_moe.py -k 'MoESingleton or Topk'` subset was terminated after it stopped producing output partway through the already-passing subset; the final code change after the passing run was license-header-only.
