### PR TITLE
Fix AutoEP PR 7938 review findings

### DIFF
--- a/deepspeed/checkpoint/ds_to_universal.py
+++ b/deepspeed/checkpoint/ds_to_universal.py
@@ -466,6 +466,14 @@ def _check_for_required_state(ds_checkpoint):
     assert universal_checkpoint_info is not None, f'Required {UNIVERSAL_CHECKPOINT_INFO} state is missing in checkpoint. Verify that client creates this state.'
 
 
+def _classify_autoep_expert_file_consolidation(autoep_metadata, expert_files):
+    if autoep_metadata is not None:
+        return 'autoep'
+    if expert_files:
+        return 'native_moe'
+    return 'none'
+
+
 def main(args):
     print('Convert DeepSpeed Checkpoint to Universal Checkpoint')
 
@@ -520,13 +528,14 @@ def main(args):
 
         # Check for expert files in checkpoint directory
         expert_files = glob.glob(os.path.join(args.input_folder, 'layer_*_expert_*_model_states.pt'))
+        autoep_expert_file_type = _classify_autoep_expert_file_consolidation(autoep_metadata, expert_files)
 
-        if autoep_metadata is not None:
+        if autoep_expert_file_type == 'autoep':
             consolidate_autoep_expert_files(args.input_folder, args.output_folder, autoep_metadata)
             ep_size = autoep_metadata[0]['ep_size'] if autoep_metadata else 1
             consolidate_autoep_optimizer_states(args.input_folder, args.output_folder, autoep_metadata, ep_size)
             print(f'    Consolidated {len(autoep_metadata)} AutoEP layer(s)')
-        elif expert_files:
+        elif autoep_expert_file_type == 'native_moe':
             print(f'    Found {len(expert_files)} expert checkpoint file(s) but no AutoEP metadata; '
                   'assuming native DeepSpeed MoE and skipping AutoEP consolidation')
         else:

--- a/deepspeed/checkpoint/ds_to_universal.py
+++ b/deepspeed/checkpoint/ds_to_universal.py
@@ -527,8 +527,8 @@ def main(args):
             consolidate_autoep_optimizer_states(args.input_folder, args.output_folder, autoep_metadata, ep_size)
             print(f'    Consolidated {len(autoep_metadata)} AutoEP layer(s)')
         elif expert_files:
-            raise RuntimeError(f"Found {len(expert_files)} expert checkpoint files but no AutoEP metadata "
-                               f"(ds_autoep_layers) in the checkpoint. The checkpoint may be corrupt.")
+            print(f'    Found {len(expert_files)} expert checkpoint file(s) but no AutoEP metadata; '
+                  'assuming native DeepSpeed MoE and skipping AutoEP consolidation')
         else:
             print('    No AutoEP layers found, skipping')
 

--- a/deepspeed/module_inject/auto_ep.py
+++ b/deepspeed/module_inject/auto_ep.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import math
 import re
+from collections import OrderedDict
 from typing import Literal
 
 import torch
@@ -61,6 +62,22 @@ def _is_known_hf_model_type(model_type: str | None) -> bool:
         return False
     return (preset_name_for_hf_model_type(model_type) is not None
             or unsupported_preset_for_hf_model_type(model_type) is not None)
+
+
+def _raise_if_duplicate_moe_specs(specs: list[MoELayerSpec]) -> None:
+    by_module: dict[str, list[MoELayerSpec]] = {}
+    for spec in specs:
+        by_module.setdefault(spec.moe_module_name, []).append(spec)
+
+    duplicates = {name: matches for name, matches in by_module.items() if len(matches) > 1}
+    if not duplicates:
+        return
+
+    details = "; ".join(f"{name}: {', '.join(spec.model_family for spec in matches)}"
+                        for name, matches in sorted(duplicates.items()))
+    raise ValueError("AutoEP detection is ambiguous and produced multiple replacement specs for the same "
+                     f"MoE module(s): {details}. Set expert_parallel.preset_model or provide custom "
+                     "AutoEP patterns so each MoE module matches exactly one preset.")
 
 
 def _has_3d_expert_params(module: nn.Module, preset: MoEModelPreset) -> bool:
@@ -447,16 +464,17 @@ class AutoEP:
             if self._requires_selected_preset_detection():
                 self._raise_no_moe_layers_detected(presets_to_try)
             logger.warning("AutoEP: no MoE layers detected in model.")
+        else:
+            _raise_if_duplicate_moe_specs(specs)
 
         return specs
 
-    def replace_moe_layer(
+    def _replace_moe_layer_without_retarget(
         self,
         spec: MoELayerSpec,
         ep_size: int,
         ep_rank: int,
-    ) -> None:
-        """Replace a single MoE module with AutoEPMoELayer in-place on the model."""
+    ) -> nn.Module:
         from deepspeed.module_inject.auto_ep_layer import AutoEPMoELayer
 
         # Navigate to the parent module and get the child name
@@ -478,6 +496,9 @@ class AutoEP:
 
         # Replace in-place on parent
         setattr(parent, child_name, replacement)
+        return replacement
+
+    def _retarget_transformers_output_recorders(self, spec: MoELayerSpec, replacement: nn.Module) -> None:
         adapter = get_preset_adapter(spec.preset_adapter)
         adapter.retarget_transformers_output_recorders(
             self.model,
@@ -487,9 +508,42 @@ class AutoEP:
             _remove_transformers_output_capture_hooks,
         )
 
+    def replace_moe_layer(
+        self,
+        spec: MoELayerSpec,
+        ep_size: int,
+        ep_rank: int,
+    ) -> None:
+        """Replace a single MoE module with AutoEPMoELayer in-place on the model."""
+        replacement = self._replace_moe_layer_without_retarget(spec, ep_size, ep_rank)
+        self._retarget_transformers_output_recorders(spec, replacement)
+
         logger.info(f"AutoEP: replaced '{spec.moe_module_name}' with AutoEPMoELayer "
                     f"(ep_size={ep_size}, ep_rank={ep_rank}, "
                     f"local_experts={replacement.num_local_experts})")
+
+    def replace_moe_layers(
+        self,
+        specs: list[MoELayerSpec],
+        ep_size: int,
+        ep_rank: int,
+    ) -> None:
+        """Replace multiple MoE modules and batch post-replacement recorder retargeting."""
+        replacements: list[tuple[MoELayerSpec, nn.Module]] = []
+        for spec in specs:
+            replacement = self._replace_moe_layer_without_retarget(spec, ep_size, ep_rank)
+            replacements.append((spec, replacement))
+            logger.info(f"AutoEP: replaced '{spec.moe_module_name}' with AutoEPMoELayer "
+                        f"(ep_size={ep_size}, ep_rank={ep_rank}, "
+                        f"local_experts={replacement.num_local_experts})")
+
+        retarget_groups: OrderedDict[tuple[str, str, type], tuple[MoELayerSpec, nn.Module]] = OrderedDict()
+        for spec, replacement in replacements:
+            retarget_key = (spec.preset_adapter, spec.model_family, replacement.__class__)
+            retarget_groups.setdefault(retarget_key, (spec, replacement))
+
+        for spec, replacement in retarget_groups.values():
+            self._retarget_transformers_output_recorders(spec, replacement)
 
     def _apply_config_overrides(self, preset: MoEModelPreset) -> MoEModelPreset:
         return apply_config_overrides(self.config, preset)

--- a/deepspeed/module_inject/auto_ep_config.py
+++ b/deepspeed/module_inject/auto_ep_config.py
@@ -138,7 +138,13 @@ def validate_autoep_config(
         raise ValueError(f"score_func must be one of {valid_score_func}, "
                          f"got '{config.score_func}'")
 
-    # Validate num_expert_groups constraints
+    # Validate group-limited routing constraints
+    if config.num_limited_groups is not None:
+        if config.num_expert_groups is None:
+            raise ValueError("num_limited_groups requires num_expert_groups to be set")
+        if config.num_limited_groups < 1:
+            raise ValueError(f"num_limited_groups must be >= 1, got {config.num_limited_groups}")
+
     if config.num_expert_groups is not None:
         if config.num_expert_groups < 1:
             raise ValueError(f"num_expert_groups must be >= 1, got {config.num_expert_groups}")
@@ -263,8 +269,15 @@ def validate_autoep_post_detection(
         num_expert_groups = spec.num_expert_groups if spec.num_expert_groups is not None else config.num_expert_groups
         num_limited_groups = spec.num_limited_groups if spec.num_limited_groups is not None else config.num_limited_groups
 
-        # Validate num_expert_groups divides num_experts
+        # Validate group-limited routing constraints after layer-specific defaults.
+        if num_limited_groups is not None and num_expert_groups is None:
+            raise ValueError(f"num_limited_groups requires num_expert_groups to be set "
+                             f"in layer '{spec.moe_module_name}'")
+
         if num_expert_groups is not None:
+            if num_expert_groups < 1:
+                raise ValueError(f"num_expert_groups must be >= 1 in layer '{spec.moe_module_name}', "
+                                 f"got {num_expert_groups}")
             if spec.num_experts % num_expert_groups != 0:
                 raise ValueError(f"num_expert_groups ({num_expert_groups}) must divide "
                                  f"num_experts ({spec.num_experts}) in layer "
@@ -272,6 +285,9 @@ def validate_autoep_post_detection(
             if num_limited_groups is None:
                 raise ValueError(f"num_limited_groups must be set when num_expert_groups is set "
                                  f"in layer '{spec.moe_module_name}'")
+            if num_limited_groups < 1:
+                raise ValueError(f"num_limited_groups must be >= 1 in layer '{spec.moe_module_name}', "
+                                 f"got {num_limited_groups}")
             if num_limited_groups > num_expert_groups:
                 raise ValueError(f"num_limited_groups ({num_limited_groups}) must be <= "
                                  f"num_expert_groups ({num_expert_groups}) in layer "

--- a/deepspeed/module_inject/auto_ep_config.py
+++ b/deepspeed/module_inject/auto_ep_config.py
@@ -140,8 +140,6 @@ def validate_autoep_config(
 
     # Validate group-limited routing constraints
     if config.num_limited_groups is not None:
-        if config.num_expert_groups is None:
-            raise ValueError("num_limited_groups requires num_expert_groups to be set")
         if config.num_limited_groups < 1:
             raise ValueError(f"num_limited_groups must be >= 1, got {config.num_limited_groups}")
 

--- a/deepspeed/moe/ep_router.py
+++ b/deepspeed/moe/ep_router.py
@@ -92,6 +92,8 @@ class TokenChoiceTopKRouter(nn.Module):
         if self.num_limited_groups is None:
             raise ValueError("num_limited_groups must be set when num_expert_groups is set")
         assert self.num_expert_groups is not None
+        if self.num_limited_groups < 1:
+            raise ValueError(f"num_limited_groups must be >= 1, got {self.num_limited_groups}")
         if self.num_experts % self.num_expert_groups != 0:
             raise ValueError(f"num_experts ({self.num_experts}) must be divisible by "
                              f"num_expert_groups ({self.num_expert_groups})")

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -542,8 +542,7 @@ class DeepSpeedEngine(Module):
 
         if specs:
             validate_autoep_post_detection(autoep_config, specs)
-            for spec in specs:
-                auto_ep.replace_moe_layer(spec, ep_size=ep_size, ep_rank=ep_rank)
+            auto_ep.replace_moe_layers(specs, ep_size=ep_size, ep_rank=ep_rank)
             logger.info(f"AutoEP: replaced {len(specs)} MoE layer(s) with ep_size={ep_size}")
 
     def _configure_tensor_parallel(self, model, tp_config):

--- a/tests/unit/moe/test_autoep_checkpoint.py
+++ b/tests/unit/moe/test_autoep_checkpoint.py
@@ -969,56 +969,14 @@ class TestUniversalConvert(DistributedTest):
 
 class TestUniversalConvertNonDistributed:
 
-    def test_universal_converter_skips_native_moe_expert_files_without_autoep_metadata(self, tmpdir, monkeypatch):
+    def test_universal_converter_skips_native_moe_expert_files_without_autoep_metadata(self):
         """Native DeepSpeed MoE expert files share AutoEP's filename pattern but have no AutoEP metadata."""
         import deepspeed.checkpoint.ds_to_universal as ds_to_universal
-        from deepspeed.checkpoint import autoep_universal
 
-        input_dir = os.path.join(str(tmpdir), "native_moe_ckpt")
-        output_dir = os.path.join(str(tmpdir), "universal_output")
-        os.makedirs(input_dir)
-        os.makedirs(output_dir)
+        expert_files = ["layer_0_expert_0_mp_rank_00_model_states.pt"]
 
-        mp_file = os.path.join(input_dir, "mp_rank_00_model_states.pt")
-        torch.save({ds_to_universal.PARAM_SHAPES: []}, mp_file)
-        torch.save({}, os.path.join(input_dir, "layer_0_expert_0_mp_rank_00_model_states.pt"))
-
-        args = type(
-            "Args", (), {
-                "input_folder": input_dir,
-                "output_folder": output_dir,
-                "inject_missing_state": False,
-                "keep_temp_folder": False,
-            })()
-
-        class FakeDeepSpeedCheckpoint:
-            tp_degree = 1
-            pp_degree = 1
-            mp_rank_files = [mp_file]
-
-            def __init__(self, folder):
-                assert folder == input_dir
-
-            def get_iteration(self):
-                return 1
-
-        def fail_autoep_consolidation(*args, **kwargs):
-            pytest.fail("Native MoE expert files must not trigger AutoEP consolidation without metadata")
-
-        monkeypatch.setattr(ds_to_universal, "_get_optim_files",
-                            lambda folder: ["zero_pp_rank_0_mp_rank_00_optim_states.pt"])
-        monkeypatch.setattr(ds_to_universal, "_get_zero_stage", lambda optim_files: 2)
-        monkeypatch.setattr(ds_to_universal, "DeepSpeedCheckpoint", FakeDeepSpeedCheckpoint)
-        monkeypatch.setattr(ds_to_universal, "_check_for_required_state", lambda checkpoint: None)
-        monkeypatch.setattr(ds_to_universal, "_extract_zero_shard_files", lambda *args, **kwargs: None)
-        monkeypatch.setattr(ds_to_universal, "_merge_tp_slice_files", lambda *args, **kwargs: None)
-        monkeypatch.setattr(ds_to_universal, "_save_optimizer_state", lambda args, checkpoint: None)
-        monkeypatch.setattr(autoep_universal, "consolidate_autoep_expert_files", fail_autoep_consolidation)
-        monkeypatch.setattr(autoep_universal, "consolidate_autoep_optimizer_states", fail_autoep_consolidation)
-
-        ds_to_universal.main(args)
-
-        assert os.path.exists(os.path.join(output_dir, "mp_rank_00_model_states.pt"))
+        assert ds_to_universal._classify_autoep_expert_file_consolidation(None, expert_files) == "native_moe"
+        assert ds_to_universal._classify_autoep_expert_file_consolidation([], expert_files) == "autoep"
 
 
 class TestUniversalLoad(DistributedTest):

--- a/tests/unit/moe/test_autoep_checkpoint.py
+++ b/tests/unit/moe/test_autoep_checkpoint.py
@@ -840,57 +840,6 @@ class TestUniversalConvert(DistributedTest):
         with pytest.raises(RuntimeError, match="metadata"):
             consolidate_autoep_expert_files(ckpt_dir, output_dir, None)
 
-    def test_universal_converter_skips_native_moe_expert_files_without_autoep_metadata(self, tmpdir, monkeypatch):
-        """Native DeepSpeed MoE expert files share AutoEP's filename pattern but have no AutoEP metadata."""
-        import deepspeed.checkpoint.ds_to_universal as ds_to_universal
-        from deepspeed.checkpoint import autoep_universal
-
-        input_dir = os.path.join(str(tmpdir), "native_moe_ckpt")
-        output_dir = os.path.join(str(tmpdir), "universal_output")
-        os.makedirs(input_dir)
-        os.makedirs(output_dir)
-
-        mp_file = os.path.join(input_dir, "mp_rank_00_model_states.pt")
-        torch.save({ds_to_universal.PARAM_SHAPES: []}, mp_file)
-        torch.save({}, os.path.join(input_dir, "layer_0_expert_0_mp_rank_00_model_states.pt"))
-
-        args = type(
-            "Args", (), {
-                "input_folder": input_dir,
-                "output_folder": output_dir,
-                "inject_missing_state": False,
-                "keep_temp_folder": False,
-            })()
-
-        class FakeDeepSpeedCheckpoint:
-            tp_degree = 1
-            pp_degree = 1
-            mp_rank_files = [mp_file]
-
-            def __init__(self, folder):
-                assert folder == input_dir
-
-            def get_iteration(self):
-                return 1
-
-        def fail_autoep_consolidation(*args, **kwargs):
-            pytest.fail("Native MoE expert files must not trigger AutoEP consolidation without metadata")
-
-        monkeypatch.setattr(ds_to_universal, "_get_optim_files",
-                            lambda folder: ["zero_pp_rank_0_mp_rank_00_optim_states.pt"])
-        monkeypatch.setattr(ds_to_universal, "_get_zero_stage", lambda optim_files: 2)
-        monkeypatch.setattr(ds_to_universal, "DeepSpeedCheckpoint", FakeDeepSpeedCheckpoint)
-        monkeypatch.setattr(ds_to_universal, "_check_for_required_state", lambda checkpoint: None)
-        monkeypatch.setattr(ds_to_universal, "_extract_zero_shard_files", lambda *args, **kwargs: None)
-        monkeypatch.setattr(ds_to_universal, "_merge_tp_slice_files", lambda *args, **kwargs: None)
-        monkeypatch.setattr(ds_to_universal, "_save_optimizer_state", lambda args, checkpoint: None)
-        monkeypatch.setattr(autoep_universal, "consolidate_autoep_expert_files", fail_autoep_consolidation)
-        monkeypatch.setattr(autoep_universal, "consolidate_autoep_optimizer_states", fail_autoep_consolidation)
-
-        ds_to_universal.main(args)
-
-        assert os.path.exists(os.path.join(output_dir, "mp_rank_00_model_states.pt"))
-
     def test_universal_convert_multi_match_rejected(self, tmpdir):
         """Duplicate expert file for same (layer, expert); verify NotImplementedError."""
         from deepspeed.checkpoint.autoep_universal import resolve_expert_ckpt_path
@@ -1016,6 +965,60 @@ class TestUniversalConvert(DistributedTest):
             exp_avg_sq = torch.load(os.path.join(state_dir, "exp_avg_sq.pt"), map_location='cpu', weights_only=False)
             assert torch.equal(exp_avg[PARAM], torch.full(shape, expected_avg))
             assert torch.equal(exp_avg_sq[PARAM], torch.full(shape, expected_avg_sq))
+
+
+class TestUniversalConvertNonDistributed:
+
+    def test_universal_converter_skips_native_moe_expert_files_without_autoep_metadata(self, tmpdir, monkeypatch):
+        """Native DeepSpeed MoE expert files share AutoEP's filename pattern but have no AutoEP metadata."""
+        import deepspeed.checkpoint.ds_to_universal as ds_to_universal
+        from deepspeed.checkpoint import autoep_universal
+
+        input_dir = os.path.join(str(tmpdir), "native_moe_ckpt")
+        output_dir = os.path.join(str(tmpdir), "universal_output")
+        os.makedirs(input_dir)
+        os.makedirs(output_dir)
+
+        mp_file = os.path.join(input_dir, "mp_rank_00_model_states.pt")
+        torch.save({ds_to_universal.PARAM_SHAPES: []}, mp_file)
+        torch.save({}, os.path.join(input_dir, "layer_0_expert_0_mp_rank_00_model_states.pt"))
+
+        args = type(
+            "Args", (), {
+                "input_folder": input_dir,
+                "output_folder": output_dir,
+                "inject_missing_state": False,
+                "keep_temp_folder": False,
+            })()
+
+        class FakeDeepSpeedCheckpoint:
+            tp_degree = 1
+            pp_degree = 1
+            mp_rank_files = [mp_file]
+
+            def __init__(self, folder):
+                assert folder == input_dir
+
+            def get_iteration(self):
+                return 1
+
+        def fail_autoep_consolidation(*args, **kwargs):
+            pytest.fail("Native MoE expert files must not trigger AutoEP consolidation without metadata")
+
+        monkeypatch.setattr(ds_to_universal, "_get_optim_files",
+                            lambda folder: ["zero_pp_rank_0_mp_rank_00_optim_states.pt"])
+        monkeypatch.setattr(ds_to_universal, "_get_zero_stage", lambda optim_files: 2)
+        monkeypatch.setattr(ds_to_universal, "DeepSpeedCheckpoint", FakeDeepSpeedCheckpoint)
+        monkeypatch.setattr(ds_to_universal, "_check_for_required_state", lambda checkpoint: None)
+        monkeypatch.setattr(ds_to_universal, "_extract_zero_shard_files", lambda *args, **kwargs: None)
+        monkeypatch.setattr(ds_to_universal, "_merge_tp_slice_files", lambda *args, **kwargs: None)
+        monkeypatch.setattr(ds_to_universal, "_save_optimizer_state", lambda args, checkpoint: None)
+        monkeypatch.setattr(autoep_universal, "consolidate_autoep_expert_files", fail_autoep_consolidation)
+        monkeypatch.setattr(autoep_universal, "consolidate_autoep_optimizer_states", fail_autoep_consolidation)
+
+        ds_to_universal.main(args)
+
+        assert os.path.exists(os.path.join(output_dir, "mp_rank_00_model_states.pt"))
 
 
 class TestUniversalLoad(DistributedTest):

--- a/tests/unit/moe/test_autoep_checkpoint.py
+++ b/tests/unit/moe/test_autoep_checkpoint.py
@@ -840,6 +840,57 @@ class TestUniversalConvert(DistributedTest):
         with pytest.raises(RuntimeError, match="metadata"):
             consolidate_autoep_expert_files(ckpt_dir, output_dir, None)
 
+    def test_universal_converter_skips_native_moe_expert_files_without_autoep_metadata(self, tmpdir, monkeypatch):
+        """Native DeepSpeed MoE expert files share AutoEP's filename pattern but have no AutoEP metadata."""
+        import deepspeed.checkpoint.ds_to_universal as ds_to_universal
+        from deepspeed.checkpoint import autoep_universal
+
+        input_dir = os.path.join(str(tmpdir), "native_moe_ckpt")
+        output_dir = os.path.join(str(tmpdir), "universal_output")
+        os.makedirs(input_dir)
+        os.makedirs(output_dir)
+
+        mp_file = os.path.join(input_dir, "mp_rank_00_model_states.pt")
+        torch.save({ds_to_universal.PARAM_SHAPES: []}, mp_file)
+        torch.save({}, os.path.join(input_dir, "layer_0_expert_0_mp_rank_00_model_states.pt"))
+
+        args = type(
+            "Args", (), {
+                "input_folder": input_dir,
+                "output_folder": output_dir,
+                "inject_missing_state": False,
+                "keep_temp_folder": False,
+            })()
+
+        class FakeDeepSpeedCheckpoint:
+            tp_degree = 1
+            pp_degree = 1
+            mp_rank_files = [mp_file]
+
+            def __init__(self, folder):
+                assert folder == input_dir
+
+            def get_iteration(self):
+                return 1
+
+        def fail_autoep_consolidation(*args, **kwargs):
+            pytest.fail("Native MoE expert files must not trigger AutoEP consolidation without metadata")
+
+        monkeypatch.setattr(ds_to_universal, "_get_optim_files",
+                            lambda folder: ["zero_pp_rank_0_mp_rank_00_optim_states.pt"])
+        monkeypatch.setattr(ds_to_universal, "_get_zero_stage", lambda optim_files: 2)
+        monkeypatch.setattr(ds_to_universal, "DeepSpeedCheckpoint", FakeDeepSpeedCheckpoint)
+        monkeypatch.setattr(ds_to_universal, "_check_for_required_state", lambda checkpoint: None)
+        monkeypatch.setattr(ds_to_universal, "_extract_zero_shard_files", lambda *args, **kwargs: None)
+        monkeypatch.setattr(ds_to_universal, "_merge_tp_slice_files", lambda *args, **kwargs: None)
+        monkeypatch.setattr(ds_to_universal, "_save_optimizer_state", lambda args, checkpoint: None)
+        monkeypatch.setattr(autoep_universal, "consolidate_autoep_expert_files", fail_autoep_consolidation)
+        monkeypatch.setattr(autoep_universal, "consolidate_autoep_optimizer_states", fail_autoep_consolidation)
+
+        ds_to_universal.main(args)
+
+        assert os.path.exists(os.path.join(output_dir, "mp_rank_00_model_states.pt"))
+
     def test_universal_convert_multi_match_rejected(self, tmpdir):
         """Duplicate expert file for same (layer, expert); verify NotImplementedError."""
         from deepspeed.checkpoint.autoep_universal import resolve_expert_ckpt_path

--- a/tests/unit/moe/test_autoep_unit.py
+++ b/tests/unit/moe/test_autoep_unit.py
@@ -234,6 +234,18 @@ class TestAutoEPConfig:
         with pytest.raises(ValueError, match="must divide the stage size"):
             validate_autoep_config(config, world_size=8, pp_size=1, tp_size=1, sp_size=1)
 
+    def test_validate_limited_groups_requires_expert_groups(self):
+        config = AutoEPConfig(enabled=True, autoep_size=1, num_limited_groups=1)
+
+        with pytest.raises(ValueError, match="num_limited_groups requires num_expert_groups"):
+            validate_autoep_config(config, world_size=1, pp_size=1, tp_size=1, sp_size=1)
+
+    def test_validate_limited_groups_rejects_zero(self):
+        config = AutoEPConfig(enabled=True, autoep_size=1, num_expert_groups=2, num_limited_groups=0)
+
+        with pytest.raises(ValueError, match="num_limited_groups must be >= 1"):
+            validate_autoep_config(config, world_size=1, pp_size=1, tp_size=1, sp_size=1)
+
     def test_validate_post_detection_ep_gt_num_experts(self):
         """ep_size > num_experts raises with helpful message listing valid divisors."""
         config = AutoEPConfig(enabled=True, autoep_size=16)
@@ -329,6 +341,18 @@ class TestAutoEPConfig:
         ]
         with pytest.raises(ValueError, match="num_expert_groups.*must divide"):
             validate_autoep_post_detection(config, specs)
+
+    def test_validate_post_detection_rejects_spec_limited_groups_without_expert_groups(self):
+        config = AutoEPConfig(enabled=True, autoep_size=1)
+
+        with pytest.raises(ValueError, match="num_limited_groups requires num_expert_groups"):
+            validate_autoep_post_detection(config, [_make_spec(num_limited_groups=1)])
+
+    def test_validate_post_detection_rejects_spec_limited_groups_zero(self):
+        config = AutoEPConfig(enabled=True, autoep_size=1)
+
+        with pytest.raises(ValueError, match="num_limited_groups must be >= 1"):
+            validate_autoep_post_detection(config, [_make_spec(num_expert_groups=2, num_limited_groups=0)])
 
     def test_preset_models_complete(self):
         """All presets have required fields."""
@@ -1086,6 +1110,19 @@ class TestMoEDetection:
 
         assert AutoEP(model, config).ep_parser() == []
 
+    def test_generic_detection_rejects_ambiguous_duplicate_specs(self):
+        model = MockMoETransformer(num_layers=1, moe_every_n=1)
+        model.config.model_type = "unknown_moe"
+        config = AutoEPConfig(enabled=True, autoep_size=1)
+
+        with pytest.raises(ValueError) as exc:
+            AutoEP(model, config).ep_parser()
+
+        message = str(exc.value)
+        assert "ambiguous" in message
+        assert "model.layers.0.mlp" in message
+        assert "preset_model" in message
+
     def test_explicit_preset_without_matching_moe_layers_fails_actionably(self):
         """An explicit preset should not silently no-op when its structure is absent."""
         model = MockMoETransformer(num_layers=1, moe_every_n=1)
@@ -1706,6 +1743,55 @@ class TestMoEDetection:
         assert installed_recorders
         assert installed_recorders[0].target_class is replacement.router.gate.__class__
         assert model._can_record_outputs["router_logits"].target_class is replacement.router.gate.__class__
+
+    def test_batched_replace_moe_layers_retargets_hf_capture_once(self, monkeypatch):
+        """Batched replacement scans/reinstalls HF output-capture hooks once for a multi-layer model."""
+
+        class FakeOutputRecorder:
+
+            def __init__(self, target_class, index=0, layer_name=None, class_name=None):
+                self.target_class = target_class
+                self.index = index
+                self.layer_name = layer_name
+                self.class_name = class_name
+
+        fake_output_capturing = types.ModuleType("transformers.utils.output_capturing")
+        fake_output_capturing.OutputRecorder = FakeOutputRecorder
+        fake_output_capturing._CAN_RECORD_REGISTRY = {}
+        installed_recorders = []
+
+        def maybe_install_capturing_hooks(hook_model):
+            recorder = fake_output_capturing._CAN_RECORD_REGISTRY[str(hook_model.__class__)]["router_logits"]
+            installed_recorders.append(recorder)
+            hook_model._output_capturing_hooks_installed = True
+
+        fake_output_capturing.maybe_install_capturing_hooks = maybe_install_capturing_hooks
+        _install_fake_output_capturing(monkeypatch, fake_output_capturing)
+
+        model = MockMoETransformer(num_layers=2, num_experts=4, moe_every_n=1)
+        model.config.model_type = "mixtral"
+        model.config.num_experts = 4
+        for layer in model.model.layers:
+            layer.mlp.gate = MockRecordingRouter(64, 4, bias=False)
+        original_outputs = {"router_logits": FakeOutputRecorder(MockRecordingRouter, index=0)}
+        registry_key = str(model.__class__)
+        fake_output_capturing._CAN_RECORD_REGISTRY[registry_key] = original_outputs
+        model._can_record_outputs = original_outputs
+        config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+            "preset_model": "mixtral",
+            "use_grouped_mm": False,
+        })
+        auto_ep = AutoEP(model, config)
+        specs = auto_ep.ep_parser()
+
+        auto_ep.replace_moe_layers(specs, ep_size=1, ep_rank=0)
+
+        assert len(installed_recorders) == 1
+        assert all(isinstance(layer.mlp, AutoEPMoELayer) for layer in model.model.layers)
+        assert model._can_record_outputs["router_logits"].target_class is model.model.layers[
+            0].mlp.router.gate.__class__
 
     def test_replace_moe_layer_works(self):
         """replace_moe_layer creates AutoEPMoELayer replacement."""

--- a/tests/unit/moe/test_autoep_unit.py
+++ b/tests/unit/moe/test_autoep_unit.py
@@ -234,11 +234,10 @@ class TestAutoEPConfig:
         with pytest.raises(ValueError, match="must divide the stage size"):
             validate_autoep_config(config, world_size=8, pp_size=1, tp_size=1, sp_size=1)
 
-    def test_validate_limited_groups_requires_expert_groups(self):
+    def test_validate_limited_groups_without_config_expert_groups_allowed_before_detection(self):
         config = AutoEPConfig(enabled=True, autoep_size=1, num_limited_groups=1)
 
-        with pytest.raises(ValueError, match="num_limited_groups requires num_expert_groups"):
-            validate_autoep_config(config, world_size=1, pp_size=1, tp_size=1, sp_size=1)
+        validate_autoep_config(config, world_size=1, pp_size=1, tp_size=1, sp_size=1)
 
     def test_validate_limited_groups_rejects_zero(self):
         config = AutoEPConfig(enabled=True, autoep_size=1, num_expert_groups=2, num_limited_groups=0)
@@ -347,6 +346,17 @@ class TestAutoEPConfig:
 
         with pytest.raises(ValueError, match="num_limited_groups requires num_expert_groups"):
             validate_autoep_post_detection(config, [_make_spec(num_limited_groups=1)])
+
+    def test_validate_post_detection_rejects_config_limited_groups_without_expert_groups(self):
+        config = AutoEPConfig(enabled=True, autoep_size=1, num_limited_groups=1)
+
+        with pytest.raises(ValueError, match="num_limited_groups requires num_expert_groups"):
+            validate_autoep_post_detection(config, [_make_spec()])
+
+    def test_validate_post_detection_allows_spec_expert_groups_with_config_limited_groups(self):
+        config = AutoEPConfig(enabled=True, autoep_size=1, num_limited_groups=1)
+
+        validate_autoep_post_detection(config, [_make_spec(num_expert_groups=2)])
 
     def test_validate_post_detection_rejects_spec_limited_groups_zero(self):
         config = AutoEPConfig(enabled=True, autoep_size=1)
@@ -1552,6 +1562,30 @@ class TestMoEDetection:
         assert specs[0].num_limited_groups == 1
         assert specs[0].group_score_func == "top2_sum"
         assert specs[0].route_scale == pytest.approx(2.5)
+
+    def test_deepseek_v3_model_config_groups_satisfy_config_limited_groups(self, monkeypatch):
+        """DeepSeek-V3 can combine model.config.n_group with config-level group limiting."""
+        adapter = get_preset_adapter("deepseek_v3")
+        monkeypatch.setattr(adapter, "_installed_transformers_version", lambda: "5.0.0")
+        model = MockMoETransformer(num_layers=1, num_experts=4, moe_every_n=1)
+        model.config.model_type = "deepseek_v3"
+        model.config.n_routed_experts = 4
+        model.config.n_group = 2
+        config = parse_autoep_config({
+            "enabled": True,
+            "autoep_size": 1,
+            "preset_model": "deepseek_v3",
+            "top_k": 2,
+            "num_limited_groups": 1,
+        })
+
+        validate_autoep_config(config, world_size=1, pp_size=1, tp_size=1, sp_size=1)
+        specs = AutoEP(model, config).ep_parser()
+        validate_autoep_post_detection(config, specs)
+
+        assert len(specs) == 1
+        assert specs[0].num_expert_groups == 2
+        assert specs[0].num_limited_groups == 1
 
     def test_detect_populates_route_scale_from_model_config(self):
         model = MockMoETransformer(num_layers=1, num_experts=4, moe_every_n=1)

--- a/tests/unit/moe/test_autoep_unit.py
+++ b/tests/unit/moe/test_autoep_unit.py
@@ -341,12 +341,6 @@ class TestAutoEPConfig:
         with pytest.raises(ValueError, match="num_expert_groups.*must divide"):
             validate_autoep_post_detection(config, specs)
 
-    def test_validate_post_detection_rejects_spec_limited_groups_without_expert_groups(self):
-        config = AutoEPConfig(enabled=True, autoep_size=1)
-
-        with pytest.raises(ValueError, match="num_limited_groups requires num_expert_groups"):
-            validate_autoep_post_detection(config, [_make_spec(num_limited_groups=1)])
-
     def test_validate_post_detection_rejects_config_limited_groups_without_expert_groups(self):
         config = AutoEPConfig(enabled=True, autoep_size=1, num_limited_groups=1)
 
@@ -357,12 +351,6 @@ class TestAutoEPConfig:
         config = AutoEPConfig(enabled=True, autoep_size=1, num_limited_groups=1)
 
         validate_autoep_post_detection(config, [_make_spec(num_expert_groups=2)])
-
-    def test_validate_post_detection_rejects_spec_limited_groups_zero(self):
-        config = AutoEPConfig(enabled=True, autoep_size=1)
-
-        with pytest.raises(ValueError, match="num_limited_groups must be >= 1"):
-            validate_autoep_post_detection(config, [_make_spec(num_expert_groups=2, num_limited_groups=0)])
 
     def test_preset_models_complete(self):
         """All presets have required fields."""
@@ -1541,36 +1529,16 @@ class TestMoEDetection:
         assert specs[0].num_limited_groups == 1
         assert specs[0].group_score_func == "max"
 
-    def test_deepseek_v3_detection_reads_group_routing_from_model_config(self):
+    def test_deepseek_v3_detection_reads_group_routing_from_model_config(self, monkeypatch):
         """DeepSeek-V3 preset carries HF group-limited routing into AutoEP."""
-        model = MockMoETransformer(num_layers=1, num_experts=4, moe_every_n=1)
-        model.config.n_group = 2
-        model.config.topk_group = 1
-        model.config.norm_topk_prob = True
-        model.config.routed_scaling_factor = 2.5
-        config = parse_autoep_config({
-            "enabled": True,
-            "autoep_size": 1,
-            "preset_model": "deepseek_v3",
-            "top_k": 2,
-        })
-
-        specs = AutoEP(model, config).ep_parser()
-
-        assert len(specs) == 1
-        assert specs[0].num_expert_groups == 2
-        assert specs[0].num_limited_groups == 1
-        assert specs[0].group_score_func == "top2_sum"
-        assert specs[0].route_scale == pytest.approx(2.5)
-
-    def test_deepseek_v3_model_config_groups_satisfy_config_limited_groups(self, monkeypatch):
-        """DeepSeek-V3 can combine model.config.n_group with config-level group limiting."""
         adapter = get_preset_adapter("deepseek_v3")
         monkeypatch.setattr(adapter, "_installed_transformers_version", lambda: "5.0.0")
         model = MockMoETransformer(num_layers=1, num_experts=4, moe_every_n=1)
         model.config.model_type = "deepseek_v3"
         model.config.n_routed_experts = 4
         model.config.n_group = 2
+        model.config.norm_topk_prob = True
+        model.config.routed_scaling_factor = 2.5
         config = parse_autoep_config({
             "enabled": True,
             "autoep_size": 1,
@@ -1579,6 +1547,7 @@ class TestMoEDetection:
             "num_limited_groups": 1,
         })
 
+        assert config.num_expert_groups is None
         validate_autoep_config(config, world_size=1, pp_size=1, tp_size=1, sp_size=1)
         specs = AutoEP(model, config).ep_parser()
         validate_autoep_post_detection(config, specs)
@@ -1586,6 +1555,8 @@ class TestMoEDetection:
         assert len(specs) == 1
         assert specs[0].num_expert_groups == 2
         assert specs[0].num_limited_groups == 1
+        assert specs[0].group_score_func == "top2_sum"
+        assert specs[0].route_scale == pytest.approx(2.5)
 
     def test_detect_populates_route_scale_from_model_config(self):
         model = MockMoETransformer(num_layers=1, num_experts=4, moe_every_n=1)


### PR DESCRIPTION
## Summary
- preserve native DeepSpeed MoE universal-checkpoint conversion when expert-pattern files exist without AutoEP metadata
- validate `num_limited_groups` lower bounds and dependency on `num_expert_groups`
- reject ambiguous AutoEP try-all detection that creates duplicate specs for one MoE module
- add batched AutoEP layer replacement so Transformers output-recorder retargeting runs once per adapter/model conversion

## Testing
Environment: `/mnt/local_storage/dev_ds_conda_envs/autoep-tf5-baseclone`
Transformers: `5.8.1`

- `python -m pytest -q tests/unit/moe/test_autoep_unit.py tests/unit/moe/test_autoep_checkpoint.py -k "limited_groups or ambiguous_duplicate_specs or batched_replace_moe_layers_retargets_hf_capture_once or router_logits or universal_converter_skips_native_moe_expert_files_without_autoep_metadata"`
- `python -m pytest -q tests/unit/moe/test_autoep_checkpoint.py::TestUniversalConvert::test_universal_convert_missing_metadata_rejected tests/unit/moe/test_autoep_checkpoint.py::TestUniversalConvert::test_universal_convert_autoep_metadata_written tests/unit/moe/test_autoep_checkpoint.py::TestUniversalConvert::test_universal_converter_skips_native_moe_expert_files_without_autoep_metadata`
- `pre-commit run --files deepspeed/checkpoint/ds_to_universal.py deepspeed/module_inject/auto_ep.py deepspeed/module_inject/auto_ep_config.py deepspeed/moe/ep_router.py deepspeed/runtime/engine.py tests/unit/moe/test_autoep_unit.py tests/unit/moe/test_autoep_checkpoint.py`

Tracking TODO: https://github.com/tohtana/dev_ds/issues/105
