### PR TITLE
Use generic flat grad partition protocol

### DIFF
--- a/deepspeed/compile/init_z1.py
+++ b/deepspeed/compile/init_z1.py
@@ -19,6 +19,17 @@ def _empty_grad_buffer(param):
     return torch.empty([0], dtype=param.dtype, device=param.device)
 
 
+class _FlatPartitionGradBufferGroup(list):
+
+    def __init__(self, grad_buffers, flat_partition, release_fn):
+        super().__init__(grad_buffers)
+        self.flat_partition = flat_partition
+        self._release_fn = release_fn
+
+    def release_grad_buffers(self):
+        self._release_fn()
+
+
 def _build_partition_grad_views(optimizer, group_idx):
     missing = object()
     original_all_grad_tensors = optimizer.all_grad_tensors.get(group_idx, missing)
@@ -133,7 +144,6 @@ def init_z1(engine, backend, compile_config, compile_kwargs, schedule=None, use_
 
         optimizer._deepcompile_z1_grad_buffer_metadata = grad_buffer_metadata
         optimizer._deepcompile_z1_current_grad_buffers = {}
-        optimizer._deepcompile_z1_current_flat_grad_buffers = {}
 
         def set_z1_grad_buffer(is_gradient_accumulation_boundary):
             if not is_gradient_accumulation_boundary:
@@ -142,14 +152,12 @@ def init_z1(engine, backend, compile_config, compile_kwargs, schedule=None, use_
                 return
 
             current_grad_buffers = {}
-            current_flat_grad_buffers = {}
             for group_idx in range(len(optimizer.bit16_groups)):
                 flat_grad_buffer, group_grad_buffers = _build_flat_partition_grad_views(optimizer, group_idx)
-                current_flat_grad_buffers[group_idx] = flat_grad_buffer
-                current_grad_buffers[group_idx] = group_grad_buffers
+                current_grad_buffers[group_idx] = _FlatPartitionGradBufferGroup(
+                    group_grad_buffers, flat_grad_buffer, lambda group_idx=group_idx: release_grad_buffer(group_idx))
                 for (param_id, _, offset), grad_buffer in zip(grad_buffer_metadata[group_idx], group_grad_buffers):
                     dc.update_param_grad_buffer(param_id, grad_buffer, offset)
-            optimizer._deepcompile_z1_current_flat_grad_buffers = current_flat_grad_buffers
             optimizer._deepcompile_z1_current_grad_buffers = current_grad_buffers
             optimizer.averaged_gradients = current_grad_buffers
 
@@ -160,8 +168,6 @@ def init_z1(engine, backend, compile_config, compile_kwargs, schedule=None, use_
                     dc.update_param_grad_buffer(param_id, _empty_grad_buffer(param), 0)
                 if idx in optimizer._deepcompile_z1_current_grad_buffers:
                     optimizer._deepcompile_z1_current_grad_buffers[idx] = None
-                if idx in optimizer._deepcompile_z1_current_flat_grad_buffers:
-                    optimizer._deepcompile_z1_current_flat_grad_buffers[idx] = None
 
         optimizer._deepcompile_z1_release_grad_buffers = release_grad_buffer
 

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -2054,6 +2054,26 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             p.grad = None  # in step
             p.grad_accum = None
 
+    # DeepCompile passes may provide a gradient group that already owns a flat ZeRO partition.
+    def _get_preflattened_grad_partition(self, group_idx):
+        grad_group = self.averaged_gradients[group_idx]
+        flat_grad_partition = getattr(grad_group, "flat_partition", None)
+        if flat_grad_partition is None:
+            return None
+        return flat_grad_partition.view(-1)
+
+    def _release_preflattened_grad_buffers(self, group_idx=None):
+        if group_idx is None:
+            group_indices = list(self.averaged_gradients.keys())
+        else:
+            group_indices = [group_idx]
+
+        for idx in group_indices:
+            grad_group = self.averaged_gradients.get(idx)
+            release_grad_buffers = getattr(grad_group, "release_grad_buffers", None)
+            if callable(release_grad_buffers):
+                release_grad_buffers()
+
     def reset_cpu_buffers(self):
         self.norm_for_param_grads = {}
         self.local_overflow = False
@@ -2133,9 +2153,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         if self.overflow:
             see_memory_usage('After overflow before clearing gradients')
             self.zero_grad(set_to_none=True)
-            release_deepcompile_grad_buffers = getattr(self, "_deepcompile_z1_release_grad_buffers", None)
-            if release_deepcompile_grad_buffers is not None:
-                release_deepcompile_grad_buffers()
+            self._release_preflattened_grad_buffers()
             if self.cpu_offload:
                 self.reset_cpu_buffers()
             else:
@@ -2187,16 +2205,11 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
                 # create a flat gradients for parameters updated by this process
                 # If we are last partition, ensure we have same size grads and partition size, if not pad with zero tensors
-                deepcompile_flat_grad_buffers = getattr(self, "_deepcompile_z1_current_flat_grad_buffers", None)
-                flat_grad_partition = None
-                if deepcompile_flat_grad_buffers is not None:
-                    flat_grad_partition = deepcompile_flat_grad_buffers.get(i)
-                    if flat_grad_partition is not None:
-                        flat_grad_partition = flat_grad_partition.view(-1)
-                        assert flat_grad_partition.numel() == self.partition_size[i], \
-                            "DeepCompile flat gradient partition has different number of elements than partition size {} {} {} {}".format(
-                                flat_grad_partition.numel(), self.partition_size[i], i, partition_id)
-
+                flat_grad_partition = self._get_preflattened_grad_partition(i)
+                if flat_grad_partition is not None:
+                    assert flat_grad_partition.numel() == self.partition_size[i], \
+                        "Pre-flattened gradient partition has different number of elements than partition size {} {} {} {}".format(
+                            flat_grad_partition.numel(), self.partition_size[i], i, partition_id)
                 if flat_grad_partition is None:
                     if partition_id == dist.get_world_size(group=self.real_dp_process_group[i]) - 1:
                         flat_grad_partition = self.flatten_dense_tensors_aligned(self.averaged_gradients[i],
@@ -2213,11 +2226,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 # release all the gradient since we have already created a necessary copy in dp_grad_partition(ZeRO stage2)
                 self.free_grad_in_param_list(self.params_in_partition[i])
 
+                self._release_preflattened_grad_buffers(i)
                 self.averaged_gradients[i] = None
                 self.all_grad_tensors[i] = None
-                release_deepcompile_grad_buffers = getattr(self, "_deepcompile_z1_release_grad_buffers", None)
-                if release_deepcompile_grad_buffers is not None:
-                    release_deepcompile_grad_buffers(i)
                 self.unscale_and_clip_grads([single_grad_partition], scaled_global_grad_norm)
 
                 self.timers(OPTIMIZER_GRADIENTS_TIMER).stop()

--- a/tests/unit/v1/compile/test_compile_zero.py
+++ b/tests/unit/v1/compile/test_compile_zero.py
@@ -160,6 +160,10 @@ class TestDeepCompile(DistributedTest):
         assert current_grad_buffers
         assert all(group_buffers is not None for group_buffers in current_grad_buffers.values())
         assert any(buffer.numel() > 0 for group_buffers in current_grad_buffers.values() for buffer in group_buffers)
+        assert not hasattr(optimizer, "_deepcompile_z1_current_flat_grad_buffers")
+        for group_idx, group_buffers in current_grad_buffers.items():
+            assert group_buffers.flat_partition.numel() == optimizer.partition_size[group_idx]
+            assert callable(group_buffers.release_grad_buffers)
 
         engine.step()
 


### PR DESCRIPTION
Summary:
- Replace the ZeRO optimizer step's DeepCompile-specific flat grad buffer lookup with a generic per-gradient-group `flat_partition` protocol.
- Keep the DeepCompile-specific flat partition buffer and release callback wiring in `deepspeed/compile/init_z1.py`.
- Update the ZeRO-1 DeepCompile release test to assert the generic protocol and the removal of the old `_deepcompile_z1_current_flat_grad_buffers` optimizer attribute.

Testing:
- `pre-commit run --files deepspeed/compile/init_z1.py deepspeed/runtime/zero/stage_1_and_2.py tests/unit/v1/compile/test_compile_zero.py`
- `git diff --check`
- `python -m compileall -q deepspeed/compile/init_z1.py deepspeed/runtime/zero/stage_1_and_2.py tests/unit/v1/compile/test_compile_zero.py`
- 4xH100 `torchrun --standalone --nproc_per_node=4` DeepCompile ZeRO-1 grad buffer protocol smoke passed.